### PR TITLE
Add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ npm test
 
 ## 11. Salud y monitoreo
 - Backend: `GET /` responde con mensaje simple.
-- Se pueden añadir endpoints de healthcheck para liveness/readiness.
+- Endpoint de healthcheck: `GET /health` devuelve `{ "status": "ok" }` para liveness/readiness.
 
 ## 12. Backups básicos
 ```bash

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,3 +14,9 @@ app.include_router(auth.router)
 @app.get("/")
 def read_root():
     return {"message": "BVG Attendance API"}
+
+
+@app.get("/health", tags=["health"])
+def health_check():
+    """Simple healthcheck endpoint for monitoring."""
+    return {"status": "ok"}

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/health` endpoint for backend monitoring
- document healthcheck in README
- add test covering health endpoint

## Testing
- `DATABASE_URL=sqlite:///test.db pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3c1a6a58883229b608327cb90c706