### PR TITLE
feat: add proxy management and tests

### DIFF
--- a/backend/tests/test_proxies.py
+++ b/backend/tests/test_proxies.py
@@ -1,0 +1,66 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import Base, engine, SessionLocal
+from app import models
+
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+client = TestClient(app)
+
+def setup_entities():
+    db = SessionLocal()
+    person = models.Person(
+        type=models.PersonType.TERCERO,
+        name="Proxy Person",
+        document="PDOCX",
+        email=None,
+    )
+    shareholder = models.Shareholder(
+        code="SH_PRX",
+        name="Alice",
+        document="D2",
+        email="a@example.com",
+        actions=10,
+    )
+    db.add_all([person, shareholder])
+    db.commit()
+    db.refresh(person)
+    db.refresh(shareholder)
+    db.close()
+    return person.id, shareholder.id
+
+def test_create_and_list_proxies():
+    person_id, shareholder_id = setup_entities()
+    payload = {
+        "election_id": 1,
+        "proxy_person_id": person_id,
+        "tipo_doc": "ID",
+        "num_doc": "123",
+        "fecha_otorg": "2024-01-01",
+        "fecha_vigencia": "2030-01-01",
+        "pdf_url": "http://example.com/proxy.pdf",
+        "assignments": [
+            {
+                "shareholder_id": shareholder_id,
+                "weight_actions_snapshot": 10,
+                "valid_from": None,
+                "valid_until": None,
+            }
+        ],
+    }
+    response = client.post("/elections/1/proxies", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["proxy_person_id"] == person_id
+    assert len(data["assignments"]) == 1
+
+    response = client.get("/elections/1/proxies")
+    assert response.status_code == 200
+    proxies = response.json()
+    assert len(proxies) == 1
+    assert proxies[0]["id"] == data["id"]
+
+    # cleanup so subsequent tests start with a clean database
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+

--- a/frontend/src/hooks/useProxies.ts
+++ b/frontend/src/hooks/useProxies.ts
@@ -1,0 +1,57 @@
+import { useQuery, useMutation } from '../lib/react-query';
+import { useAuth } from '../context/AuthContext';
+
+export interface Proxy {
+  id: number;
+  num_doc: string;
+  pdf_url: string;
+}
+
+export interface ProxyPayload {
+  proxy_person_id: number;
+  tipo_doc: string;
+  num_doc: string;
+  fecha_otorg: string;
+  fecha_vigencia?: string | null;
+  pdf_url: string;
+  election_id?: number;
+}
+
+export const useProxies = (electionId: number) => {
+  const { token } = useAuth();
+  return useQuery<Proxy[]>({
+    queryKey: ['proxies', electionId],
+    queryFn: async () => {
+      const res = await fetch(`/elections/${electionId}/proxies`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error('Error al cargar poderes');
+      return res.json();
+    },
+  });
+};
+
+export const useCreateProxy = (
+  electionId: number,
+  onSuccess?: () => void,
+  onError?: (err: any) => void
+) => {
+  const { token } = useAuth();
+  return useMutation<any, ProxyPayload>({
+    mutationFn: async (payload) => {
+      const res = await fetch(`/elections/${electionId}/proxies`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ ...payload, election_id: electionId }),
+      });
+      if (!res.ok) throw new Error('Error al crear poder');
+      return res.json();
+    },
+    onSuccess,
+    onError,
+  });
+};
+

--- a/frontend/src/pages/Proxies.tsx
+++ b/frontend/src/pages/Proxies.tsx
@@ -1,20 +1,109 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useToast } from '../components/ui/toast';
+import { useProxies, useCreateProxy } from '../hooks/useProxies';
 
 const Proxies: React.FC = () => {
+  const electionId = 1; // demo election
+  const toast = useToast();
+  const { data: proxies, refetch } = useProxies(electionId);
+  const initialForm = {
+    proxy_person_id: '',
+    tipo_doc: '',
+    num_doc: '',
+    fecha_otorg: '',
+    fecha_vigencia: '',
+    pdf_url: '',
+  };
+  const [form, setForm] = useState(initialForm);
+
+  const createProxy = useCreateProxy(
+    electionId,
+    () => {
+      toast('Poder registrado');
+      setForm(initialForm);
+      refetch();
+    },
+    (err) => toast(err.message)
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createProxy.mutate({
+      proxy_person_id: Number(form.proxy_person_id),
+      tipo_doc: form.tipo_doc,
+      num_doc: form.num_doc,
+      fecha_otorg: form.fecha_otorg,
+      fecha_vigencia: form.fecha_vigencia || null,
+      pdf_url: form.pdf_url,
+    });
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Gestión de Apoderados</h1>
-      <p className="text-sm text-gray-600">Permite registrar poderes para accionistas.</p>
-      <form className="space-y-2 max-w-md">
-        <input className="border px-3 py-2 rounded w-full" placeholder="Número de documento" />
-        <input className="border px-3 py-2 rounded w-full" placeholder="Fecha de otorgamiento" type="date" />
-        <input className="border px-3 py-2 rounded w-full" placeholder="Fecha de vigencia" type="date" />
-        <input className="border px-3 py-2 rounded w-full" type="file" />
-        <button className="bg-green-600 text-white px-4 py-2 rounded" type="button">Guardar</button>
+      <form className="space-y-2 max-w-md" onSubmit={handleSubmit}>
+        <input
+          className="border px-3 py-2 rounded w-full"
+          name="proxy_person_id"
+          placeholder="ID persona apoderada"
+          value={form.proxy_person_id}
+          onChange={handleChange}
+        />
+        <input
+          className="border px-3 py-2 rounded w-full"
+          name="tipo_doc"
+          placeholder="Tipo de documento"
+          value={form.tipo_doc}
+          onChange={handleChange}
+        />
+        <input
+          className="border px-3 py-2 rounded w-full"
+          name="num_doc"
+          placeholder="Número de documento"
+          value={form.num_doc}
+          onChange={handleChange}
+        />
+        <input
+          className="border px-3 py-2 rounded w-full"
+          name="fecha_otorg"
+          placeholder="Fecha de otorgamiento"
+          type="date"
+          value={form.fecha_otorg}
+          onChange={handleChange}
+        />
+        <input
+          className="border px-3 py-2 rounded w-full"
+          name="fecha_vigencia"
+          placeholder="Fecha de vigencia"
+          type="date"
+          value={form.fecha_vigencia}
+          onChange={handleChange}
+        />
+        <input
+          className="border px-3 py-2 rounded w-full"
+          name="pdf_url"
+          placeholder="URL del PDF"
+          value={form.pdf_url}
+          onChange={handleChange}
+        />
+        <button className="bg-green-600 text-white px-4 py-2 rounded" type="submit">
+          Guardar
+        </button>
       </form>
-      <p className="text-sm text-gray-600">Funcionalidad completa pendiente.</p>
+      {proxies && proxies.length > 0 && (
+        <ul className="list-disc pl-4">
+          {proxies.map((p) => (
+            <li key={p.id}>Poder #{p.id} - Documento {p.num_doc}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };
 
 export default Proxies;
+


### PR DESCRIPTION
## Summary
- fetch and create proxies from the API with a new React hook
- wire Proxies page to list and submit proxy data
- cover proxy endpoints with backend tests

## Testing
- `DATABASE_URL=sqlite:///./test.db pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a3c56da96c83229123153ea5eb565b