### PR TITLE
Add JWT validation, role checks, and election management APIs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from .routers import shareholders, attendance, proxies, auth
+from .routers import shareholders, attendance, proxies, auth, elections
 from .database import Base, engine
 
 Base.metadata.create_all(bind=engine)
@@ -10,6 +10,7 @@ app.include_router(shareholders.router)
 app.include_router(attendance.router)
 app.include_router(proxies.router)
 app.include_router(auth.router)
+app.include_router(elections.router)
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -99,6 +99,19 @@ class ProxyAssignment(Base):
     proxy = relationship("Proxy", back_populates="assignments")
 
 
+class ElectionStatus(str, enum.Enum):
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+
+
+class Election(Base):
+    __tablename__ = "elections"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    date = Column(Date, nullable=False)
+    status = Column(Enum(ElectionStatus), default=ElectionStatus.OPEN, nullable=False)
+
+
 class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True, index=True)

--- a/backend/app/routers/elections.py
+++ b/backend/app/routers/elections.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from .. import schemas, models, database
+from ..security import get_current_user, require_role
+
+router = APIRouter(prefix="/elections", tags=["elections"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("", response_model=schemas.Election, dependencies=[require_role(["REGISTRADOR_BVG"])])
+def create_election(election: schemas.ElectionCreate, db: Session = Depends(get_db)):
+    db_election = models.Election(**election.dict())
+    db.add(db_election)
+    db.commit()
+    db.refresh(db_election)
+    return db_election
+
+
+@router.get("", response_model=List[schemas.Election], dependencies=[Depends(get_current_user)])
+def list_elections(db: Session = Depends(get_db)):
+    return db.query(models.Election).all()
+
+
+@router.patch("/{election_id}/status", response_model=schemas.Election, dependencies=[require_role(["REGISTRADOR_BVG"])])
+def update_status(election_id: int, payload: schemas.ElectionStatusUpdate, db: Session = Depends(get_db)):
+    election = db.query(models.Election).filter_by(id=election_id).first()
+    if not election:
+        raise HTTPException(status_code=404, detail="Election not found")
+    election.status = payload.status
+    db.commit()
+    db.refresh(election)
+    return election

--- a/backend/app/routers/proxies.py
+++ b/backend/app/routers/proxies.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from datetime import date
 from typing import List
 from .. import schemas, models, database
+from ..security import get_current_user, require_role
 
 router = APIRouter(prefix="/elections/{election_id}/proxies", tags=["proxies"])
 
@@ -13,7 +14,7 @@ def get_db():
     finally:
         db.close()
 
-@router.post("", response_model=schemas.Proxy)
+@router.post("", response_model=schemas.Proxy, dependencies=[require_role(["REGISTRADOR_BVG"])])
 def create_proxy(election_id: int, proxy: schemas.ProxyCreate, db: Session = Depends(get_db)):
     if proxy.fecha_vigencia and proxy.fecha_vigencia < date.today():
         raise HTTPException(status_code=400, detail="proxy expired")
@@ -30,6 +31,6 @@ def create_proxy(election_id: int, proxy: schemas.ProxyCreate, db: Session = Dep
     db_proxy.assignments = assignments
     return db_proxy
 
-@router.get("", response_model=List[schemas.Proxy])
+@router.get("", response_model=List[schemas.Proxy], dependencies=[Depends(get_current_user)])
 def list_proxies(election_id: int, db: Session = Depends(get_db)):
     return db.query(models.Proxy).filter_by(election_id=election_id).all()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date
 from typing import Optional, List
 from pydantic import BaseModel, EmailStr
-from .models import AttendanceMode, PersonType, ProxyStatus
+from .models import AttendanceMode, PersonType, ProxyStatus, ElectionStatus
 
 class ShareholderBase(BaseModel):
     code: str
@@ -93,3 +93,24 @@ class Proxy(ProxyBase):
 
     class Config:
         orm_mode = True
+
+
+class ElectionBase(BaseModel):
+    name: str
+    date: date
+
+
+class ElectionCreate(ElectionBase):
+    pass
+
+
+class Election(ElectionBase):
+    id: int
+    status: ElectionStatus
+
+    class Config:
+        orm_mode = True
+
+
+class ElectionStatusUpdate(BaseModel):
+    status: ElectionStatus

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,30 @@
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import os
+import jwt
+
+SECRET_KEY = os.getenv("JWT_SECRET", "changeme")
+ALGORITHM = "HS256"
+
+security = HTTPBearer()
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        role: str = payload.get("role")
+        if username is None or role is None:
+            raise HTTPException(status_code=401, detail="Token inválido")
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expirado")
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=401, detail="Token inválido")
+    return {"username": username, "role": role}
+
+
+def require_role(roles):
+    def role_dependency(user=Depends(get_current_user)):
+        if user["role"] not in roles:
+            raise HTTPException(status_code=403, detail="No autorizado")
+    return Depends(role_dependency)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,8 @@
 import sys, os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
 import pytest
 from app.database import Base, engine
 

--- a/backend/tests/test_attendance.py
+++ b/backend/tests/test_attendance.py
@@ -1,16 +1,33 @@
+import hashlib
 from fastapi.testclient import TestClient
 from app.main import app
-from app.database import Base, engine
+from app.database import Base, engine, SessionLocal
+from app import models
 
-Base.metadata.create_all(bind=engine)
 client = TestClient(app)
 
+
+def setup_env():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    db.add(models.User(username="AdminBVG", hashed_password=hashlib.sha256("BVG2025".encode()).hexdigest(), role="REGISTRADOR_BVG"))
+    db.commit()
+    db.close()
+    token = client.post("/auth/login", json={"username": "AdminBVG", "password": "BVG2025"}).json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.post("/elections", json={"name": "Demo", "date": "2024-01-01"}, headers=headers)
+    election_id = resp.json()["id"]
+    return headers, election_id
+
+
 def test_attendance_history_endpoint():
+    headers, election_id = setup_env()
     data = [{"code": "SH1", "name": "Alice", "document": "D1", "email": "a@example.com", "actions": 10}]
-    assert client.post("/elections/1/shareholders/import", json=data).status_code == 200
-    assert client.post("/elections/1/attendance/SH1/mark", json={"mode": "PRESENCIAL"}).status_code == 200
-    assert client.post("/elections/1/attendance/SH1/mark", json={"mode": "VIRTUAL"}).status_code == 200
-    resp = client.get("/elections/1/attendance/history", params={"code": "SH1"})
+    assert client.post(f"/elections/{election_id}/shareholders/import", json=data, headers=headers).status_code == 200
+    assert client.post(f"/elections/{election_id}/attendance/SH1/mark", json={"mode": "PRESENCIAL"}, headers=headers).status_code == 200
+    assert client.post(f"/elections/{election_id}/attendance/SH1/mark", json={"mode": "VIRTUAL"}, headers=headers).status_code == 200
+    resp = client.get(f"/elections/{election_id}/attendance/history", params={"code": "SH1"}, headers=headers)
     assert resp.status_code == 200
     history = resp.json()
     assert len(history) == 2

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,7 +3,7 @@ import hashlib
 import pytest
 
 from app.main import app
-from app.database import SessionLocal
+from app.database import Base, engine, SessionLocal
 from app import models
 
 client = TestClient(app)
@@ -11,6 +11,8 @@ client = TestClient(app)
 
 @pytest.fixture(scope="module")
 def admin_user():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
     db = SessionLocal()
     db.add(
         models.User(

--- a/backend/tests/test_proxies.py
+++ b/backend/tests/test_proxies.py
@@ -1,11 +1,25 @@
+import hashlib
 from fastapi.testclient import TestClient
 from app.main import app
 from app.database import Base, engine, SessionLocal
 from app import models
 
-Base.metadata.drop_all(bind=engine)
-Base.metadata.create_all(bind=engine)
 client = TestClient(app)
+
+
+def setup_env():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    db.add(models.User(username="AdminBVG", hashed_password=hashlib.sha256("BVG2025".encode()).hexdigest(), role="REGISTRADOR_BVG"))
+    db.commit()
+    db.close()
+    token = client.post("/auth/login", json={"username": "AdminBVG", "password": "BVG2025"}).json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.post("/elections", json={"name": "Demo", "date": "2024-01-01"}, headers=headers)
+    election_id = resp.json()["id"]
+    return headers, election_id
+
 
 def setup_entities():
     db = SessionLocal()
@@ -29,10 +43,12 @@ def setup_entities():
     db.close()
     return person.id, shareholder.id
 
+
 def test_create_and_list_proxies():
+    headers, election_id = setup_env()
     person_id, shareholder_id = setup_entities()
     payload = {
-        "election_id": 1,
+        "election_id": election_id,
         "proxy_person_id": person_id,
         "tipo_doc": "ID",
         "num_doc": "123",
@@ -48,19 +64,14 @@ def test_create_and_list_proxies():
             }
         ],
     }
-    response = client.post("/elections/1/proxies", json=payload)
+    response = client.post(f"/elections/{election_id}/proxies", json=payload, headers=headers)
     assert response.status_code == 200
     data = response.json()
     assert data["proxy_person_id"] == person_id
     assert len(data["assignments"]) == 1
 
-    response = client.get("/elections/1/proxies")
+    response = client.get(f"/elections/{election_id}/proxies", headers=headers)
     assert response.status_code == 200
     proxies = response.json()
     assert len(proxies) == 1
     assert proxies[0]["id"] == data["id"]
-
-    # cleanup so subsequent tests start with a clean database
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-


### PR DESCRIPTION
## Summary
- add JWT helper and role-based authorization
- secure existing routers with token validation
- implement election CRUD endpoints and models

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a3cb8ada508322849d2365a82f289f