### PR TITLE
Add draft election state with editing limits

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -104,6 +104,7 @@ class ProxyAssignment(Base):
 
 
 class ElectionStatus(str, enum.Enum):
+    DRAFT = "DRAFT"
     OPEN = "OPEN"
     CLOSED = "CLOSED"
 
@@ -113,7 +114,9 @@ class Election(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     date = Column(Date, nullable=False)
-    status = Column(Enum(ElectionStatus), default=ElectionStatus.OPEN, nullable=False)
+    status = Column(
+        Enum(ElectionStatus), default=ElectionStatus.DRAFT, nullable=False
+    )
 
 
 class User(Base):

--- a/backend/app/routers/elections.py
+++ b/backend/app/routers/elections.py
@@ -29,12 +29,52 @@ def list_elections(db: Session = Depends(get_db)):
     return db.query(models.Election).all()
 
 
+@router.patch(
+    "/{election_id}",
+    response_model=schemas.Election,
+    dependencies=[require_role(["REGISTRADOR_BVG"])],
+)
+def update_election(
+    election_id: int, payload: schemas.ElectionUpdate, db: Session = Depends(get_db)
+):
+    election = db.query(models.Election).filter_by(id=election_id).first()
+    if not election:
+        raise HTTPException(status_code=404, detail="Election not found")
+    if election.status != models.ElectionStatus.DRAFT:
+        raise HTTPException(
+            status_code=400, detail="Only draft elections can be edited"
+        )
+    if payload.name is not None:
+        election.name = payload.name
+    if payload.date is not None:
+        election.date = payload.date
+    db.commit()
+    db.refresh(election)
+    return election
+
+
 @router.patch("/{election_id}/status", response_model=schemas.Election, dependencies=[require_role(["REGISTRADOR_BVG"])])
 def update_status(election_id: int, payload: schemas.ElectionStatusUpdate, db: Session = Depends(get_db)):
     election = db.query(models.Election).filter_by(id=election_id).first()
     if not election:
         raise HTTPException(status_code=404, detail="Election not found")
-    election.status = payload.status
+    current = election.status
+    new_status = payload.status
+    if current == models.ElectionStatus.DRAFT:
+        if new_status != models.ElectionStatus.OPEN:
+            raise HTTPException(
+                status_code=400, detail="Draft elections can only transition to OPEN"
+            )
+    elif current == models.ElectionStatus.OPEN:
+        if new_status != models.ElectionStatus.CLOSED:
+            raise HTTPException(
+                status_code=400, detail="Open elections can only transition to CLOSED"
+            )
+    else:  # CLOSED
+        raise HTTPException(
+            status_code=400, detail="Closed elections cannot change status"
+        )
+    election.status = new_status
     db.commit()
     db.refresh(election)
     return election

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -95,7 +95,12 @@ class ElectionBase(BaseModel):
 
 
 class ElectionCreate(ElectionBase):
-    pass
+    status: ElectionStatus = ElectionStatus.DRAFT
+
+
+class ElectionUpdate(BaseModel):
+    name: Optional[str] = None
+    date: Optional[date] = None
 
 
 class Election(ElectionBase):


### PR DESCRIPTION
## Summary
- allow elections to start in DRAFT state
- permit editing name/date only while DRAFT and restrict status transitions

## Testing
- `cd backend && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_b_68a3d99c3d888322a3a6e48937535cc2