### PR TITLE
Fix API base prefix and seed password hashing

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,7 +1,7 @@
 from datetime import date
-import hashlib
 from .database import SessionLocal, Base, engine
 from . import models
+from .routers.auth import hash_password
 
 Base.metadata.create_all(bind=engine)
 
@@ -10,7 +10,7 @@ def run():
     if db.query(models.User).filter_by(username="AdminBVG").first() is None:
         admin = models.User(
             username="AdminBVG",
-            hashed_password=hashlib.sha256("BVG2025".encode()).hexdigest(),
+            hashed_password=hash_password("BVG2025"),
             role="REGISTRADOR_BVG",
         )
         db.add(admin)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 export async function apiFetch<T = any>(path: string, init: RequestInit = {}): Promise<T> {
-  const base = import.meta.env.VITE_API_URL || '';
+  const base = import.meta.env.VITE_API_URL || '/api';
   const token = localStorage.getItem('token');
   const headers: HeadersInit = {
     ...(init.headers || {}),


### PR DESCRIPTION
## Summary
- default frontend API base URL to `/api` when `VITE_API_URL` missing
- seed AdminBVG password using same PBKDF2 hashing as authentication

## Testing
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4a6f3f5ac83228a321044731f1cb4