### PR TITLE
Enable configurable CORS via environment variable

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,36 @@
+import os
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    def load_dotenv(*args, **kwargs):
+        return None
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
 from .routers import shareholders, attendance, proxies, auth, elections, audit, observer
 from .database import Base, engine
+
+load_dotenv()
+
+CORS_ORIGINS_ENV = os.getenv("CORS_ORIGINS", "")
+if CORS_ORIGINS_ENV:
+    CORS_ORIGINS = [o.strip() for o in CORS_ORIGINS_ENV.split(",") if o.strip()]
+else:
+    CORS_ORIGINS = ["http://localhost:5173"]
 
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI(title="BVG Attendance API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(shareholders.router)
 app.include_router(attendance.router)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ python-multipart
 pytest
 httpx
 PyJWT
+python-dotenv


### PR DESCRIPTION
## Summary
- load optional `.env` file and read `CORS_ORIGINS`
- default to localhost when env var is missing and register CORS middleware
- include `python-dotenv` dependency

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-dotenv)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4adeb7cc483229bae4fa3e6e05eff