### PR TITLE
feat(frontend): manage election lifecycle

### DIFF
--- a/frontend/src/hooks/useElections.ts
+++ b/frontend/src/hooks/useElections.ts
@@ -6,6 +6,8 @@ export interface Election {
   name: string;
   date: string;
   status: string;
+  registration_start?: string;
+  registration_end?: string;
 }
 
 export const useElections = () => {

--- a/frontend/src/hooks/useUpdateElection.ts
+++ b/frontend/src/hooks/useUpdateElection.ts
@@ -3,20 +3,19 @@ import { apiFetch } from '../lib/api';
 import { Election } from './useElections';
 
 interface Payload {
-  name: string;
-  date: string;
-  registration_start?: string;
-  registration_end?: string;
+  id: number;
+  name?: string;
+  date?: string;
 }
 
-export const useCreateElection = (
+export const useUpdateElection = (
   onSuccess?: () => void,
   onError?: (err: any) => void
 ) => {
   return useMutation<Election, Payload>({
-    mutationFn: (payload) =>
-      apiFetch('/elections', {
-        method: 'POST',
+    mutationFn: ({ id, ...payload }) =>
+      apiFetch(`/elections/${id}`, {
+        method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       }),

--- a/frontend/src/hooks/useUpdateElectionStatus.ts
+++ b/frontend/src/hooks/useUpdateElectionStatus.ts
@@ -3,22 +3,20 @@ import { apiFetch } from '../lib/api';
 import { Election } from './useElections';
 
 interface Payload {
-  name: string;
-  date: string;
-  registration_start?: string;
-  registration_end?: string;
+  id: number;
+  status: 'DRAFT' | 'OPEN' | 'CLOSED';
 }
 
-export const useCreateElection = (
+export const useUpdateElectionStatus = (
   onSuccess?: () => void,
   onError?: (err: any) => void
 ) => {
   return useMutation<Election, Payload>({
-    mutationFn: (payload) =>
-      apiFetch('/elections', {
-        method: 'POST',
+    mutationFn: ({ id, status }) =>
+      apiFetch(`/elections/${id}/status`, {
+        method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ status }),
       }),
     onSuccess: () => {
       onSuccess?.();


### PR DESCRIPTION
## Summary
- allow creating elections with optional registration window
- enable editing, opening and closing elections from the UI
- add hooks for updating elections and their status

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a4b25dffac8322b5952af872cf6e5e