### PR TITLE
Change admin seed role to ADMIN_BVG

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -11,7 +11,7 @@ def run():
         admin = models.User(
             username="AdminBVG",
             hashed_password=hash_password("BVG2025"),
-            role="REGISTRADOR_BVG",
+            role="ADMIN_BVG",
         )
         db.add(admin)
         db.commit()


### PR DESCRIPTION
## Summary
- use ADMIN_BVG role for seeded admin user

## Testing
- `python -m app.seed` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4ba8c731c83228d6642bcbec3ce18