### PR TITLE
Fix storage parsing and login UX details

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BVG Frontend</title>
+    <link rel="icon" href="/favicon.ico" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { getItem, setItem } from '../lib/storage';
 
 interface AuthContextValue {
   token: string | null;
@@ -11,15 +12,15 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
-  const [role, setRole] = useState<string | null>(() => localStorage.getItem('role'));
-  const [username, setUsername] = useState<string | null>(() => localStorage.getItem('username'));
+  const [token, setToken] = useState<string | null>(() => getItem('token'));
+  const [role, setRole] = useState<string | null>(() => getItem('role'));
+  const [username, setUsername] = useState<string | null>(() => getItem('username'));
 
   const login = (tok: string, rol: string, user?: string) => {
-    localStorage.setItem('token', tok);
-    localStorage.setItem('role', rol);
+    setItem('token', tok);
+    setItem('role', rol);
     if (user) {
-      localStorage.setItem('username', user);
+      setItem('username', user);
       setUsername(user);
     }
     setToken(tok);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,8 @@
+import { getItem } from './storage';
+
 export async function apiFetch<T = any>(path: string, init: RequestInit = {}): Promise<T> {
   const base = import.meta.env.VITE_API_URL || '/api';
-  const token = localStorage.getItem('token');
+  const token = getItem('token');
   const headers: HeadersInit = {
     ...(init.headers || {}),
   };

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,0 +1,17 @@
+export function getItem(key: string): string | null {
+  const raw = localStorage.getItem(key);
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+export function setItem(key: string, value: string) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    localStorage.setItem(key, value);
+  }
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -52,6 +52,7 @@ const Login: React.FC = () => {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             required
+            autoComplete="username"
           />
         </div>
         <div className="mb-4">
@@ -64,6 +65,7 @@ const Login: React.FC = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            autoComplete="current-password"
           />
         </div>
         <Button


### PR DESCRIPTION
## Summary
- safely parse and store auth values in localStorage
- add autocomplete attributes to login form inputs
- include default favicon to eliminate 404 warning

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4c86e31e0832295982e94ca68027b