### PR TITLE
feat: add user management and audit views

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover - optional dependency
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import shareholders, attendance, proxies, auth, elections, audit, observer, assistants
+from .routers import shareholders, attendance, proxies, auth, elections, audit, observer, assistants, users
 from .database import Base, engine
 
 load_dotenv()
@@ -40,6 +40,7 @@ app.include_router(elections.router)
 app.include_router(audit.router)
 app.include_router(observer.router)
 app.include_router(assistants.router)
+app.include_router(users.router)
 
 @app.get("/")
 def read_root():

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from .. import models, schemas, database
+from ..routers.auth import hash_password
+from ..security import require_role
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("", response_model=List[schemas.User], dependencies=[require_role(["ADMIN_BVG"])] )
+def list_users(db: Session = Depends(get_db)):
+    return db.query(models.User).all()
+
+
+@router.post("", response_model=schemas.User, dependencies=[require_role(["ADMIN_BVG"])] )
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    if db.query(models.User).filter_by(username=user.username).first():
+        raise HTTPException(status_code=400, detail="Username already exists")
+    db_user = models.User(
+        username=user.username,
+        hashed_password=hash_password(user.password),
+        role=user.role,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.put("/{user_id}", response_model=schemas.User, dependencies=[require_role(["ADMIN_BVG"])] )
+def update_user(user_id: int, user: schemas.UserUpdate, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).get(user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.role is not None:
+        db_user.role = user.role
+    if user.password is not None:
+        db_user.hashed_password = hash_password(user.password)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@router.delete("/{user_id}", status_code=204, dependencies=[require_role(["ADMIN_BVG"])] )
+def delete_user(user_id: int, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).get(user_id)
+    if not db_user:
+        raise HTTPException(status_code=404, detail="User not found")
+    db.delete(db_user)
+    db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -186,6 +186,26 @@ class AuditLog(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class UserBase(BaseModel):
+    username: str
+    role: str
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserUpdate(BaseModel):
+    role: Optional[str] = None
+    password: Optional[str] = None
+
+
+class User(UserBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class AttendeeBase(BaseModel):
     identifier: str
     accionista: str

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
 import Votaciones from './pages/Votaciones';
 import ManageAssistants from './pages/ManageAssistants';
+import ManageUsers from './pages/ManageUsers';
+import AuditLogs from './pages/AuditLogs';
 import { ToastProvider } from './components/ui/toast';
 
 const queryClient = new QueryClient();
@@ -38,6 +40,8 @@ const App: React.FC = () => {
                 <Route element={<Layout />}>
                   <Route path="/votaciones" element={<Votaciones />} />
                   <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} />
+                  <Route path="/votaciones/:id/audit" element={<AuditLogs />} />
+                  <Route path="/users" element={<ManageUsers />} />
                 </Route>
               </Route>
               <Route element={<ProtectedRoute roles={["ADMIN_BVG", "OBSERVADOR_BVG"]} />}>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -21,6 +21,7 @@ const Layout: React.FC = () => {
       { to: '/votaciones', label: 'Votaciones' },
       { to: '/attendance', label: 'Registro de asistencia' },
       { to: '/proxies', label: 'Apoderados' },
+      { to: '/users', label: 'Usuarios' },
     ];
   } else {
     links = [{ to: '/dashboard', label: 'Dashboard' }];

--- a/frontend/src/hooks/useAuditLogs.ts
+++ b/frontend/src/hooks/useAuditLogs.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+export interface AuditLog {
+  id: number;
+  election_id: number;
+  username: string;
+  action: string;
+  details?: any;
+  ip?: string;
+  user_agent?: string;
+  created_at: string;
+}
+
+export const useAuditLogs = (electionId: number) => {
+  return useQuery<AuditLog[]>({
+    queryKey: ['audit', electionId],
+    queryFn: () => apiFetch<AuditLog[]>(`/elections/${electionId}/audit`),
+  });
+};

--- a/frontend/src/hooks/useCreateUser.ts
+++ b/frontend/src/hooks/useCreateUser.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+import { User } from './useUsers';
+
+interface Payload {
+  username: string;
+  password: string;
+  role: string;
+}
+
+export const useCreateUser = (
+  onSuccess?: () => void,
+  onError?: (err: any) => void
+) => {
+  return useMutation<User, Payload>({
+    mutationFn: (payload) =>
+      apiFetch('/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};

--- a/frontend/src/hooks/useDeleteUser.ts
+++ b/frontend/src/hooks/useDeleteUser.ts
@@ -1,0 +1,22 @@
+import { useMutation } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+interface Payload {
+  id: number;
+}
+
+export const useDeleteUser = (
+  onSuccess?: () => void,
+  onError?: (err: any) => void
+) => {
+  return useMutation<void, Payload>({
+    mutationFn: ({ id }) =>
+      apiFetch(`/users/${id}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};

--- a/frontend/src/hooks/useUpdateUser.ts
+++ b/frontend/src/hooks/useUpdateUser.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+import { User } from './useUsers';
+
+interface Payload {
+  id: number;
+  role?: string;
+  password?: string;
+}
+
+export const useUpdateUser = (
+  onSuccess?: () => void,
+  onError?: (err: any) => void
+) => {
+  return useMutation<User, Payload>({
+    mutationFn: ({ id, ...data }) =>
+      apiFetch(`/users/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError,
+  });
+};

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+export interface User {
+  id: number;
+  username: string;
+  role: string;
+}
+
+export const useUsers = () => {
+  return useQuery<User[]>({
+    queryKey: ['users'],
+    queryFn: () => apiFetch<User[]>('/users'),
+  });
+};

--- a/frontend/src/pages/AuditLogs.tsx
+++ b/frontend/src/pages/AuditLogs.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import Card from '../components/ui/card';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '../components/ui/table';
+import { useAuditLogs } from '../hooks/useAuditLogs';
+
+const AuditLogs: React.FC = () => {
+  const { id } = useParams();
+  const electionId = Number(id);
+  const { data: logs, isLoading, error } = useAuditLogs(electionId);
+
+  return (
+    <Card className="p-4">
+      <h1 className="text-lg font-semibold mb-4">Auditoría</h1>
+      {isLoading && <p>Cargando...</p>}
+      {error && <p className="text-red-600">Error al cargar auditoría</p>}
+      {!isLoading && !error && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Usuario</TableHead>
+              <TableHead>Acción</TableHead>
+              <TableHead>Fecha</TableHead>
+              <TableHead>Detalles</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs?.map((l) => (
+              <TableRow key={l.id}>
+                <TableCell>{l.username}</TableCell>
+                <TableCell>{l.action}</TableCell>
+                <TableCell>{new Date(l.created_at).toLocaleString()}</TableCell>
+                <TableCell>{l.details ? JSON.stringify(l.details) : ''}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Card>
+  );
+};
+
+export default AuditLogs;

--- a/frontend/src/pages/ManageUsers.tsx
+++ b/frontend/src/pages/ManageUsers.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import Card from '../components/ui/card';
+import Input from '../components/ui/input';
+import Button from '../components/ui/button';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '../components/ui/table';
+import { useUsers } from '../hooks/useUsers';
+import { useCreateUser } from '../hooks/useCreateUser';
+import { useUpdateUser } from '../hooks/useUpdateUser';
+import { useDeleteUser } from '../hooks/useDeleteUser';
+import { useToast } from '../components/ui/toast';
+
+const roles = ['ADMIN_BVG', 'REGISTRADOR_BVG', 'OBSERVADOR_BVG'];
+
+const ManageUsers: React.FC = () => {
+  const toast = useToast();
+  const { data: users, isLoading, error, refetch } = useUsers();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('REGISTRADOR_BVG');
+
+  const { mutate: createUser, isLoading: creating } = useCreateUser(() => {
+    toast('Usuario creado');
+    setUsername('');
+    setPassword('');
+    setRole('REGISTRADOR_BVG');
+    refetch();
+  }, (err) => toast(err.message));
+
+  const { mutate: updateUser } = useUpdateUser(() => {
+    toast('Usuario actualizado');
+    refetch();
+  }, (err) => toast(err.message));
+
+  const { mutate: deleteUser } = useDeleteUser(() => {
+    toast('Usuario eliminado');
+    refetch();
+  }, (err) => toast(err.message));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createUser({ username, password, role });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card className="p-4 max-w-md">
+        <h1 className="text-lg font-semibold mb-4">Nuevo usuario</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Usuario</label>
+            <Input value={username} onChange={(e) => setUsername(e.target.value)} required />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Contraseña</label>
+            <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Rol</label>
+            <select
+              className="border rounded w-full p-2"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+            >
+              {roles.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button type="submit" disabled={creating}>
+            Crear
+          </Button>
+        </form>
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-4">Usuarios</h2>
+        {isLoading && <p>Cargando...</p>}
+        {error && <p className="text-red-600">Error al cargar usuarios</p>}
+        {!isLoading && !error && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Usuario</TableHead>
+                <TableHead>Rol</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users?.map((u) => (
+                <TableRow key={u.id}>
+                  <TableCell>{u.username}</TableCell>
+                  <TableCell>
+                    <select
+                      className="border rounded p-1"
+                      value={u.role}
+                      onChange={(e) => updateUser({ id: u.id, role: e.target.value })}
+                    >
+                      {roles.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                  </TableCell>
+                  <TableCell>
+                    <Button variant="outline" onClick={() => deleteUser({ id: u.id })}>
+                      Eliminar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default ManageUsers;

--- a/frontend/src/pages/Votaciones.tsx
+++ b/frontend/src/pages/Votaciones.tsx
@@ -190,6 +190,12 @@ const Votaciones: React.FC = () => {
                         >
                           Gestionar asistentes
                         </Button>
+                        <Button
+                          variant="outline"
+                          onClick={() => navigate(`/votaciones/${e.id}/audit`)}
+                        >
+                          Auditoría
+                        </Button>
                       </TableCell>
                     </>
                   )}


### PR DESCRIPTION
## Summary
- add CRUD API for users with admin-only access
- expose user and audit management interfaces in frontend

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4f3fed86883229abc7bd1ca5bbe41