### PR TITLE
feat(frontend): add Poppins font and global styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BVG Frontend</title>
     <link rel="icon" href="/favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply font-sans bg-gray-50 text-gray-900 antialiased;
+  }
+}
+
 @layer utilities {
   @keyframes fade-in {
     from {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Poppins', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- load Poppins from Google Fonts
- use Poppins as default sans font in Tailwind
- apply global base styles for modern look

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68a4fdfbaeb08322b71f2cb0787e3ba1