### PR TITLE
Implement basic voting and election management

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,18 @@ except ImportError:  # pragma: no cover - optional dependency
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import shareholders, attendance, proxies, auth, elections, audit, observer, assistants, users
+from .routers import (
+    shareholders,
+    attendance,
+    proxies,
+    auth,
+    elections,
+    audit,
+    observer,
+    assistants,
+    users,
+    voting,
+)
 from .database import Base, engine
 
 load_dotenv()
@@ -41,6 +52,7 @@ app.include_router(audit.router)
 app.include_router(observer.router)
 app.include_router(assistants.router)
 app.include_router(users.router)
+app.include_router(voting.router)
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -158,3 +158,30 @@ class Attendee(Base):
     representante = Column(String)
     apoderado = Column(String)
     acciones = Column(DECIMAL, nullable=False, default=0)
+
+
+class Ballot(Base):
+    __tablename__ = "ballots"
+    id = Column(Integer, primary_key=True, index=True)
+    election_id = Column(Integer, ForeignKey("elections.id"), nullable=False)
+    title = Column(String, nullable=False)
+    options = relationship("BallotOption", back_populates="ballot")
+    votes = relationship("Vote", back_populates="ballot")
+
+
+class BallotOption(Base):
+    __tablename__ = "ballot_options"
+    id = Column(Integer, primary_key=True, index=True)
+    ballot_id = Column(Integer, ForeignKey("ballots.id"), nullable=False)
+    text = Column(String, nullable=False)
+    ballot = relationship("Ballot", back_populates="options")
+    votes = relationship("Vote", back_populates="option")
+
+
+class Vote(Base):
+    __tablename__ = "votes"
+    id = Column(Integer, primary_key=True, index=True)
+    ballot_id = Column(Integer, ForeignKey("ballots.id"), nullable=False)
+    option_id = Column(Integer, ForeignKey("ballot_options.id"), nullable=False)
+    ballot = relationship("Ballot", back_populates="votes")
+    option = relationship("BallotOption", back_populates="votes")

--- a/backend/app/routers/voting.py
+++ b/backend/app/routers/voting.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from .. import models, schemas, database
+from ..security import require_role
+
+router = APIRouter(prefix="", tags=["voting"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post(
+    "/elections/{election_id}/ballots",
+    response_model=schemas.Ballot,
+    dependencies=[require_role(["ADMIN_BVG"])]
+)
+def create_ballot(election_id: int, ballot: schemas.BallotCreate, db: Session = Depends(get_db)):
+    db_ballot = models.Ballot(election_id=election_id, title=ballot.title)
+    db.add(db_ballot)
+    db.commit()
+    db.refresh(db_ballot)
+    return db_ballot
+
+
+@router.get(
+    "/elections/{election_id}/ballots",
+    response_model=List[schemas.Ballot],
+    dependencies=[require_role(["ADMIN_BVG", "REGISTRADOR_BVG", "OBSERVADOR_BVG"])]
+)
+def list_ballots(election_id: int, db: Session = Depends(get_db)):
+    return db.query(models.Ballot).filter_by(election_id=election_id).all()
+
+
+@router.post(
+    "/ballots/{ballot_id}/options",
+    response_model=schemas.Option,
+    dependencies=[require_role(["ADMIN_BVG"])]
+)
+def create_option(ballot_id: int, option: schemas.OptionCreate, db: Session = Depends(get_db)):
+    db_option = models.BallotOption(ballot_id=ballot_id, text=option.text)
+    db.add(db_option)
+    db.commit()
+    db.refresh(db_option)
+    return db_option
+
+
+@router.post(
+    "/ballots/{ballot_id}/vote",
+    response_model=schemas.Vote,
+    dependencies=[require_role(["ADMIN_BVG", "REGISTRADOR_BVG"])]
+)
+def cast_vote(ballot_id: int, vote: schemas.VoteCreate, db: Session = Depends(get_db)):
+    option = db.query(models.BallotOption).filter_by(id=vote.option_id, ballot_id=ballot_id).first()
+    if not option:
+        raise HTTPException(status_code=400, detail="Invalid option for ballot")
+    db_vote = models.Vote(ballot_id=ballot_id, option_id=vote.option_id)
+    db.add(db_vote)
+    db.commit()
+    db.refresh(db_vote)
+    return db_vote
+
+
+@router.get(
+    "/ballots/{ballot_id}/results",
+    response_model=List[schemas.OptionResult],
+    dependencies=[require_role(["ADMIN_BVG", "REGISTRADOR_BVG", "OBSERVADOR_BVG"])]
+)
+def ballot_results(ballot_id: int, db: Session = Depends(get_db)):
+    options = db.query(models.BallotOption).filter_by(ballot_id=ballot_id).all()
+    results = []
+    for opt in options:
+        count = db.query(models.Vote).filter_by(option_id=opt.id).count()
+        results.append(schemas.OptionResult(id=opt.id, ballot_id=opt.ballot_id, text=opt.text, votes=count))
+    return results

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -16,6 +16,14 @@ class ShareholderCreate(ShareholderBase):
     pass
 
 
+class ShareholderUpdate(BaseModel):
+    code: Optional[str] = None
+    name: Optional[str] = None
+    document: Optional[str] = None
+    email: Optional[EmailStr] = None
+    actions: Optional[float] = None
+
+
 class Shareholder(ShareholderBase):
     id: int
     status: str
@@ -214,9 +222,66 @@ class AttendeeBase(BaseModel):
     acciones: float
 
 
+class AttendeeUpdate(BaseModel):
+    identifier: Optional[str] = None
+    accionista: Optional[str] = None
+    representante: Optional[str] = None
+    apoderado: Optional[str] = None
+    acciones: Optional[float] = None
+
+
 class Attendee(AttendeeBase):
     id: int
     election_id: int
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class BallotBase(BaseModel):
+    title: str
+
+
+class BallotCreate(BallotBase):
+    pass
+
+
+class Ballot(BallotBase):
+    id: int
+    election_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OptionBase(BaseModel):
+    text: str
+
+
+class OptionCreate(OptionBase):
+    pass
+
+
+class Option(OptionBase):
+    id: int
+    ballot_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class VoteBase(BaseModel):
+    option_id: int
+
+
+class VoteCreate(VoteBase):
+    pass
+
+
+class Vote(VoteBase):
+    id: int
+    ballot_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OptionResult(Option):
+    votes: int
 

--- a/backend/tests/test_elections.py
+++ b/backend/tests/test_elections.py
@@ -72,3 +72,21 @@ def test_create_list_and_update_election():
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "CLOSED"
+
+
+def test_get_and_delete_election():
+    headers = auth_headers()
+    resp = client.post(
+        "/elections", json={"name": "Temp", "date": "2024-01-01"}, headers=headers
+    )
+    election_id = resp.json()["id"]
+
+    resp = client.get(f"/elections/{election_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == election_id
+
+    resp = client.delete(f"/elections/{election_id}", headers=headers)
+    assert resp.status_code == 204
+
+    resp = client.get(f"/elections/{election_id}", headers=headers)
+    assert resp.status_code == 404

--- a/backend/tests/test_shareholders.py
+++ b/backend/tests/test_shareholders.py
@@ -86,3 +86,50 @@ def test_import_preview_and_confirm_shareholders_csv():
     )
     assert empty_resp.status_code == 200
     assert len(empty_resp.json()) == 0
+
+
+def test_get_update_delete_shareholder():
+    headers, election_id = setup_auth_and_election()
+    payload = [
+        {
+            "code": "SH1",
+            "name": "Alice",
+            "document": "D1",
+            "email": "a@example.com",
+            "actions": 10,
+        }
+    ]
+    resp = client.post(
+        f"/elections/{election_id}/shareholders/import",
+        json=payload,
+        headers=headers,
+    )
+    shareholder_id = resp.json()[0]["id"]
+
+    get_resp = client.get(
+        f"/elections/{election_id}/shareholders/{shareholder_id}",
+        headers=headers,
+    )
+    assert get_resp.status_code == 200
+    assert get_resp.json()["code"] == "SH1"
+
+    update_resp = client.put(
+        f"/elections/{election_id}/shareholders/{shareholder_id}",
+        json={"name": "Alice Updated"},
+        headers=headers,
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json()["name"] == "Alice Updated"
+
+    del_resp = client.delete(
+        f"/elections/{election_id}/shareholders/{shareholder_id}",
+        headers=headers,
+    )
+    assert del_resp.status_code == 204
+    list_resp = client.get(
+        f"/elections/{election_id}/shareholders",
+        headers=headers,
+    )
+    assert list_resp.status_code == 200
+    assert list_resp.json() == []
+

--- a/backend/tests/test_voting.py
+++ b/backend/tests/test_voting.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import Base, engine, SessionLocal
+from app import models
+from app.routers.auth import hash_password
+
+client = TestClient(app)
+
+
+def auth_headers():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    db.add(
+        models.User(
+            username="AdminBVG",
+            hashed_password=hash_password("BVG2025"),
+            role="ADMIN_BVG",
+        )
+    )
+    db.commit()
+    db.close()
+    token = client.post("/auth/login", json={"username": "AdminBVG", "password": "BVG2025"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_voting_flow():
+    headers = auth_headers()
+    resp = client.post("/elections", json={"name": "Vote", "date": "2024-01-01"}, headers=headers)
+    election_id = resp.json()["id"]
+
+    resp = client.post(
+        f"/elections/{election_id}/ballots",
+        json={"title": "Presidente"},
+        headers=headers,
+    )
+    ballot_id = resp.json()["id"]
+
+    option1 = client.post(
+        f"/ballots/{ballot_id}/options",
+        json={"text": "A"},
+        headers=headers,
+    ).json()
+    client.post(
+        f"/ballots/{ballot_id}/options",
+        json={"text": "B"},
+        headers=headers,
+    )
+
+    client.post(
+        f"/ballots/{ballot_id}/vote",
+        json={"option_id": option1["id"]},
+        headers=headers,
+    )
+
+    resp = client.get(f"/ballots/{ballot_id}/results", headers=headers)
+    assert resp.status_code == 200
+    results = {r["text"]: r["votes"] for r in resp.json()}
+    assert results["A"] == 1
+    assert results["B"] == 0


### PR DESCRIPTION
## Summary
- Extend elections API with single-election retrieval and draft-only deletion
- Introduce voting models, schemas, and router to create ballots, options, cast votes, and tally results
- Add endpoints and schemas to manage shareholders and assistants individually
- Allow proxies to be updated or deleted with assignment and PDF replacements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a52019a74c83228550205580428a1a