### PR TITLE
Fix election update and deletion endpoints

### DIFF
--- a/backend/app/routers/elections.py
+++ b/backend/app/routers/elections.py
@@ -123,3 +123,73 @@ def update_election(
     election = db.query(models.Election).filter_by(id=election_id).first()
     if not election:
         raise HTTPException(status_code=404, detail="Election not found")
+    if election.status != models.ElectionStatus.DRAFT:
+        raise HTTPException(
+            status_code=400, detail="Cannot edit election once opened"
+        )
+    data = payload.model_dump(
+        exclude_unset=True,
+        exclude={"attendance_registrars", "vote_registrars"},
+    )
+    for key, value in data.items():
+        setattr(election, key, value)
+    if (
+        payload.attendance_registrars is not None
+        or payload.vote_registrars is not None
+    ):
+        db.query(models.ElectionUserRole).filter_by(
+            election_id=election_id
+        ).delete()
+        for uid in payload.attendance_registrars or []:
+            db.add(
+                models.ElectionUserRole(
+                    election_id=election_id,
+                    user_id=uid,
+                    role=models.ElectionRole.ATTENDANCE,
+                )
+            )
+        for uid in payload.vote_registrars or []:
+            db.add(
+                models.ElectionUserRole(
+                    election_id=election_id,
+                    user_id=uid,
+                    role=models.ElectionRole.VOTE,
+                )
+            )
+    db.commit()
+    db.refresh(election)
+    return election
+
+
+@router.delete(
+    "/{election_id}",
+    status_code=204,
+    dependencies=[require_role(["ADMIN_BVG"])]
+)
+def delete_election(election_id: int, db: Session = Depends(get_db)):
+    election = db.query(models.Election).filter_by(id=election_id).first()
+    if not election:
+        raise HTTPException(status_code=404, detail="Election not found")
+    db.query(models.ElectionUserRole).filter_by(election_id=election_id).delete()
+    db.delete(election)
+    db.commit()
+    return None
+
+
+@router.patch(
+    "/{election_id}/status",
+    response_model=schemas.Election,
+    dependencies=[require_role(["ADMIN_BVG"])]
+)
+def update_election_status(
+    election_id: int,
+    payload: schemas.ElectionStatusUpdate,
+    db: Session = Depends(get_db),
+):
+    election = db.query(models.Election).filter_by(id=election_id).first()
+    if not election:
+        raise HTTPException(status_code=404, detail="Election not found")
+    election.status = payload.status
+    db.commit()
+    db.refresh(election)
+    return election

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -170,6 +170,8 @@ class ElectionUpdate(BaseModel):
     date: Optional[date] = None
     registration_start: Optional[datetime] = None
     registration_end: Optional[datetime] = None
+    attendance_registrars: Optional[List[int]] = None
+    vote_registrars: Optional[List[int]] = None
 
 
 class Election(ElectionBase):


### PR DESCRIPTION
## Summary
- complete election editing logic so updates are allowed only on draft elections and roles can be reassigned
- add deletion and status update endpoints for elections
- extend election update schema to accept registrar lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a609c3ab148322a876cf3d4455180f