### PR TITLE
feat: manage election roles per user

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from .routers import (
     assistants,
     users,
     voting,
+    election_users,
 )
 from .database import Base, engine
 
@@ -53,6 +54,7 @@ app.include_router(observer.router)
 app.include_router(assistants.router)
 app.include_router(users.router)
 app.include_router(voting.router)
+app.include_router(election_users.router)
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,7 +8,8 @@ from sqlalchemy import (
     Enum,
     DECIMAL,
     ForeignKey,
-    JSON
+    JSON,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
@@ -140,12 +141,17 @@ class User(Base):
 
 
 class ElectionRole(str, enum.Enum):
+    VOTER = "VOTER"
     ATTENDANCE = "ATTENDANCE"
     VOTE = "VOTE"
+    DELEGATE = "DELEGATE"
 
 
 class ElectionUserRole(Base):
     __tablename__ = "election_user_roles"
+    __table_args__ = (
+        UniqueConstraint("election_id", "user_id", name="uix_election_user"),
+    )
     id = Column(Integer, primary_key=True)
     election_id = Column(Integer, ForeignKey("elections.id"), nullable=False)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/backend/app/routers/election_users.py
+++ b/backend/app/routers/election_users.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from .. import models, schemas, database
+from ..security import require_role, get_current_user
+
+router = APIRouter(prefix="/elections/{election_id}/users", tags=["election-users"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("", response_model=List[schemas.ElectionUserRole], dependencies=[require_role(["ADMIN_BVG"])])
+def list_election_users(election_id: int, db: Session = Depends(get_db)):
+    rows = (
+        db.query(models.ElectionUserRole, models.User.username)
+        .join(models.User, models.ElectionUserRole.user_id == models.User.id)
+        .filter(models.ElectionUserRole.election_id == election_id)
+        .all()
+    )
+    return [
+        schemas.ElectionUserRole(
+            id=r[0].id,
+            user_id=r[0].user_id,
+            username=r[1],
+            role=r[0].role,
+        )
+        for r in rows
+    ]
+
+
+@router.post("", response_model=schemas.ElectionUserRole, dependencies=[require_role(["ADMIN_BVG"])])
+def assign_election_user(
+    election_id: int,
+    payload: schemas.ElectionUserRoleCreate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    user = db.query(models.User).filter_by(id=payload.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    assignment = (
+        db.query(models.ElectionUserRole)
+        .filter_by(election_id=election_id, user_id=payload.user_id)
+        .first()
+    )
+    if assignment:
+        assignment.role = payload.role
+    else:
+        assignment = models.ElectionUserRole(
+            election_id=election_id, user_id=payload.user_id, role=payload.role
+        )
+        db.add(assignment)
+    db.commit()
+    db.refresh(assignment)
+    return schemas.ElectionUserRole(
+        id=assignment.id,
+        user_id=assignment.user_id,
+        username=user.username,
+        role=assignment.role,
+    )
+
+
+@router.delete("/{user_id}", status_code=204, dependencies=[require_role(["ADMIN_BVG"])])
+def remove_election_user(election_id: int, user_id: int, db: Session = Depends(get_db)):
+    assignment = (
+        db.query(models.ElectionUserRole)
+        .filter_by(election_id=election_id, user_id=user_id)
+        .first()
+    )
+    if not assignment:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+    db.delete(assignment)
+    db.commit()
+    return None

--- a/backend/app/routers/elections.py
+++ b/backend/app/routers/elections.py
@@ -210,7 +210,7 @@ def update_election_status(
     election.status = payload.status
     db.commit()
     db.refresh(election)
-return election
+    return election
 
 
 @router.get(

--- a/backend/app/routers/voting.py
+++ b/backend/app/routers/voting.py
@@ -71,10 +71,12 @@ def cast_vote(
         )
         allowed = (
             db.query(models.ElectionUserRole)
-            .filter_by(
-                election_id=ballot.election_id,
-                user_id=user.id,
-                role=models.ElectionRole.VOTE,
+            .filter(
+                models.ElectionUserRole.election_id == ballot.election_id,
+                models.ElectionUserRole.user_id == user.id,
+                models.ElectionUserRole.role.in_(
+                    [models.ElectionRole.VOTE, models.ElectionRole.VOTER]
+                ),
             )
             .first()
         )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,6 +7,7 @@ from .models import (
     ProxyStatus,
     ElectionStatus,
     QuestionType,
+    ElectionRole,
 )
 
 
@@ -245,6 +246,22 @@ class UserUpdate(BaseModel):
 
 class User(UserBase):
     id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ElectionUserRoleBase(BaseModel):
+    user_id: int
+    role: ElectionRole
+
+
+class ElectionUserRoleCreate(ElectionUserRoleBase):
+    pass
+
+
+class ElectionUserRole(ElectionUserRoleBase):
+    id: int
+    username: str
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Login from './pages/Login';
 import Votaciones from './pages/Votaciones';
 import ManageAssistants from './pages/ManageAssistants';
 import ManageUsers from './pages/ManageUsers';
+import ManageElectionUsers from './pages/ManageElectionUsers';
 import AuditLogs from './pages/AuditLogs';
 import { ToastProvider } from './components/ui/toast';
 
@@ -43,11 +44,12 @@ const App: React.FC = () => {
               </Route> 
               <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}> 
                 <Route element={<Layout />}> 
-                  <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} /> 
-                  <Route path="/votaciones/:id/audit" element={<AuditLogs />} /> 
-                  <Route path="/users" element={<ManageUsers />} /> 
-                </Route> 
-              </Route> 
+                  <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} />
+                  <Route path="/votaciones/:id/audit" element={<AuditLogs />} />
+                  <Route path="/users" element={<ManageUsers />} />
+                  <Route path="/votaciones/:id/users" element={<ManageElectionUsers />} />
+                </Route>
+              </Route>
               <Route element={<ProtectedRoute roles={["ADMIN_BVG", "OBSERVADOR_BVG"]} />}>
                 <Route element={<Layout />}>
                   <Route path="/votaciones/:id/dashboard" element={<Dashboard />} />

--- a/frontend/src/hooks/useElectionUsers.ts
+++ b/frontend/src/hooks/useElectionUsers.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+export interface ElectionUser {
+  id: number;
+  user_id: number;
+  username: string;
+  role: string;
+}
+
+export const useElectionUsers = (electionId: number) => {
+  return useQuery<ElectionUser[]>({
+    queryKey: ['election-users', electionId],
+    queryFn: () => apiFetch<ElectionUser[]>(`/elections/${electionId}/users`),
+  });
+};

--- a/frontend/src/hooks/useSetElectionRole.ts
+++ b/frontend/src/hooks/useSetElectionRole.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+interface Payload {
+  userId: number;
+  role?: string;
+}
+
+export const useSetElectionRole = (
+  electionId: number,
+  onSuccess?: () => void,
+  onError?: (err: any) => void,
+) => {
+  return useMutation<any, Payload>({
+    mutationFn: ({ userId, role }) => {
+      if (!role) {
+        return apiFetch(`/elections/${electionId}/users/${userId}`, {
+          method: 'DELETE',
+        });
+      }
+      return apiFetch(`/elections/${electionId}/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, role }),
+      });
+    },
+    onSuccess,
+    onError,
+  });
+};

--- a/frontend/src/pages/ManageElectionUsers.tsx
+++ b/frontend/src/pages/ManageElectionUsers.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import Card from '../components/ui/card';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '../components/ui/table';
+import { useUsers } from '../hooks/useUsers';
+import { useElectionUsers } from '../hooks/useElectionUsers';
+import { useSetElectionRole } from '../hooks/useSetElectionRole';
+import { useToast } from '../components/ui/toast';
+
+const roleOptions = [
+  { value: '', label: 'Sin rol' },
+  { value: 'VOTER', label: 'Votante' },
+  { value: 'ATTENDANCE', label: 'Registrador de asistencia' },
+  { value: 'VOTE', label: 'Registrador de votación' },
+  { value: 'DELEGATE', label: 'Delegado' },
+];
+
+const ManageElectionUsers: React.FC = () => {
+  const { id } = useParams();
+  const electionId = Number(id);
+  const toast = useToast();
+  const { data: users } = useUsers();
+  const { data: assignments, refetch } = useElectionUsers(electionId);
+  const { mutate: setRole } = useSetElectionRole(
+    electionId,
+    () => {
+      toast('Rol actualizado');
+      refetch();
+    },
+    (err) => toast(err.message),
+  );
+
+  const roleMap = new Map(assignments?.map((a) => [a.user_id, a.role]));
+
+  return (
+    <Card className="p-4">
+      <h1 className="text-lg font-semibold mb-4">Usuarios de la elección</h1>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Usuario</TableHead>
+            <TableHead>Rol</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users?.map((u) => (
+            <TableRow key={u.id}>
+              <TableCell>{u.username}</TableCell>
+              <TableCell>
+                <select
+                  className="border rounded p-1 text-sm"
+                  value={roleMap.get(u.id) || ''}
+                  onChange={(e) =>
+                    setRole({ userId: u.id, role: e.target.value || undefined })
+                  }
+                >
+                  {roleOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+};
+
+export default ManageElectionUsers;

--- a/frontend/src/pages/Votaciones.tsx
+++ b/frontend/src/pages/Votaciones.tsx
@@ -241,6 +241,12 @@ const Votaciones: React.FC = () => {
                               >
                                 Gestionar asistentes
                               </Button>
+                              <Button
+                                variant="outline"
+                                onClick={() => navigate(`/votaciones/${e.id}/users`)}
+                              >
+                                Roles
+                              </Button>
                               {!open && <span className="text-sm text-gray-500">Bloqueada</span>}
                               <Button
                                 variant="outline"


### PR DESCRIPTION
## Summary
- allow defining VOTER, ATTENDANCE, VOTE and DELEGATE per election
- add API to assign and remove election roles
- manage election roles from admin UI

## Testing
- `pytest tests/test_election_roles.py::test_manage_election_user_roles -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a61784c1288322a5bd5fa2ab44581a