### PR TITLE
Redirect to election list after login

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -24,8 +24,7 @@ const Login: React.FC = () => {
     },
     onSuccess: (data) => {
       login(data.access_token, data.role, data.username);
-      if (data.role === 'FUNCIONAL_BVG') navigate('/votaciones/1/upload');
-      else navigate('/votaciones/1/dashboard');
+      navigate('/votaciones');
     },
     onError: (err: any) => {
       setError(err.message);


### PR DESCRIPTION
## Summary
- Avoid hardcoded redirect to election 1 after login
- Send users to the elections list so functional users see their assigned voting

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a62c1cdcdc83229761faa544ac270d