### PR TITLE
Limit registrador access to admin features

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,23 +27,19 @@ const App: React.FC = () => {
             <Routes>
               <Route path="/login" element={<Login />} />
               <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}>
-                <Route element={<Layout />}> 
-                  <Route path="/votaciones" element={<Votaciones />} /> 
-                </Route> 
-              </Route> 
-              <Route element={<ProtectedRoute roles={["FUNCIONAL_BVG"]} />}>
-                <Route element={<Layout />}> 
-                  <Route path="/votaciones/:id/upload" element={<UploadShareholders />} /> 
-                </Route> 
-              </Route> 
+                <Route element={<Layout />}>
+                  <Route path="/votaciones" element={<Votaciones />} />
+                </Route>
+              </Route>
               <Route element={<ProtectedRoute roles={["FUNCIONAL_BVG", "ADMIN_BVG"]} />}>
-                <Route element={<Layout />}> 
-                  <Route path="/votaciones/:id/attendance" element={<Asistencia />} /> 
-                  <Route path="/votaciones/:id/proxies" element={<Proxies />} /> 
-                </Route> 
-              </Route> 
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}> 
-                <Route element={<Layout />}> 
+                <Route element={<Layout />}>
+                  <Route path="/votaciones/:id/attendance" element={<Asistencia />} />
+                </Route>
+              </Route>
+              <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}>
+                <Route element={<Layout />}>
+                  <Route path="/votaciones/:id/upload" element={<UploadShareholders />} />
+                  <Route path="/votaciones/:id/proxies" element={<Proxies />} />
                   <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} />
                   <Route path="/votaciones/:id/audit" element={<AuditLogs />} />
                   <Route path="/users" element={<ManageUsers />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,19 +13,16 @@ const Layout: React.FC = () => {
   let links: { to: string; label: string }[] = [];
   if (role === 'FUNCIONAL_BVG') {
     if (base) {
-      links = [
-        { to: `${base}/upload`, label: 'Carga de padrón' },
-        { to: `${base}/attendance`, label: 'Registro' },
-        { to: `${base}/proxies`, label: 'Apoderados' },
-      ];
+      links = [{ to: `${base}/attendance`, label: 'Registro' }];
     }
   } else if (role === 'ADMIN_BVG') {
     links = [{ to: '/votaciones', label: 'Votaciones' }];
     if (base) {
       links.push(
-        { to: `${base}/dashboard`, label: 'Dashboard' },
+        { to: `${base}/upload`, label: 'Carga de padrón' },
         { to: `${base}/attendance`, label: 'Registro de asistencia' },
         { to: `${base}/proxies`, label: 'Apoderados' },
+        { to: `${base}/dashboard`, label: 'Dashboard' },
       );
     }
     links.push({ to: '/users', label: 'Usuarios' });

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -7,9 +7,10 @@ export interface User {
   role: string;
 }
 
-export const useUsers = () => {
+export const useUsers = (enabled = true) => {
   return useQuery<User[]>({
     queryKey: ['users'],
     queryFn: () => apiFetch<User[]>('/users'),
+    enabled,
   });
 };

--- a/frontend/src/pages/Votaciones.tsx
+++ b/frontend/src/pages/Votaciones.tsx
@@ -38,7 +38,7 @@ const Votaciones: React.FC = () => {
   const [editDate, setEditDate] = useState('');
 
   const { data: elections, isLoading, error, refetch } = useElections();
-  const { data: users } = useUsers();
+  const { data: users } = useUsers(role === 'ADMIN_BVG');
   const registrarUsers = users?.filter((u) => u.role === 'FUNCIONAL_BVG') || [];
   const { mutate, isLoading: creating } = useCreateElection(() => {
     toast('Votación creada');


### PR DESCRIPTION
## Summary
- avoid unauthorized /users requests by only fetching user list for admins
- hide padron upload and proxies for registrador navigation
- restrict upload and proxies routes to admin users

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a6389dbae08322b2d6848124eb2e7c