### PR TITLE
Replace deprecated SQLAlchemy Query.get usage

### DIFF
--- a/backend/app/routers/shareholders.py
+++ b/backend/app/routers/shareholders.py
@@ -246,7 +246,7 @@ def update_shareholder(
     db: Session = Depends(get_db),
     current_user = Depends(get_current_user),
 ):
-    shareholder = db.query(models.Shareholder).get(shareholder_id)
+    shareholder = db.get(models.Shareholder, shareholder_id)
     if not shareholder:
         raise HTTPException(status_code=404, detail="shareholder not found")
     enforce_registration_window(db, election_id, current_user)
@@ -274,7 +274,7 @@ def delete_shareholder(
     db: Session = Depends(get_db),
     current_user = Depends(get_current_user),
 ):
-    shareholder = db.query(models.Shareholder).get(shareholder_id)
+    shareholder = db.get(models.Shareholder, shareholder_id)
     if not shareholder:
         raise HTTPException(status_code=404, detail="shareholder not found")
     enforce_registration_window(db, election_id, current_user)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -39,7 +39,7 @@ def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
 
 @router.put("/{user_id}", response_model=schemas.User, dependencies=[require_role(["ADMIN_BVG"])] )
 def update_user(user_id: int, user: schemas.UserUpdate, db: Session = Depends(get_db)):
-    db_user = db.query(models.User).get(user_id)
+    db_user = db.get(models.User, user_id)
     if not db_user:
         raise HTTPException(status_code=404, detail="User not found")
     if user.role is not None:
@@ -53,7 +53,7 @@ def update_user(user_id: int, user: schemas.UserUpdate, db: Session = Depends(ge
 
 @router.delete("/{user_id}", status_code=204, dependencies=[require_role(["ADMIN_BVG"])] )
 def delete_user(user_id: int, db: Session = Depends(get_db)):
-    db_user = db.query(models.User).get(user_id)
+    db_user = db.get(models.User, user_id)
     if not db_user:
         raise HTTPException(status_code=404, detail="User not found")
     db.delete(db_user)


### PR DESCRIPTION
## Summary
- use `Session.get()` in user and shareholder routes to avoid SQLAlchemy 2.0 deprecation warnings

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a65dfeec8c8322ab336c071be860e5