### PR TITLE
Add auth flows and election editing

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -204,6 +204,7 @@ class ElectionUpdate(BaseModel):
     registration_end: Optional[datetime] = None
     attendance_registrars: Optional[List[int]] = None
     vote_registrars: Optional[List[int]] = None
+    questions: Optional[List["QuestionCreate"]] = None
 
 
 class Election(ElectionBase):

--- a/backend/tests/test_elections.py
+++ b/backend/tests/test_elections.py
@@ -47,6 +47,45 @@ def test_create_list_and_update_election():
     assert resp.status_code == 200
     assert resp.json()["name"] == "Demo Updated"
 
+    resp = client.patch(
+        f"/elections/{election_id}",
+        json={
+            "questions": [
+                {
+                    "text": "Q1",
+                    "type": "short_text",
+                    "required": False,
+                    "order": 0,
+                    "options": [],
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    resp = client.get(f"/elections/{election_id}/questions", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()[0]["text"] == "Q1"
+
+    resp = client.patch(
+        f"/elections/{election_id}",
+        json={
+            "questions": [
+                {
+                    "text": "Q2",
+                    "type": "short_text",
+                    "required": True,
+                    "order": 0,
+                    "options": [],
+                }
+            ]
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    resp = client.get(f"/elections/{election_id}/questions", headers=headers)
+    assert resp.json()[0]["text"] == "Q2"
+
     # open election
     resp = client.patch(
         f"/elections/{election_id}/status",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,11 +9,16 @@ import Asistencia from './pages/Asistencia';
 import Proxies from './pages/Proxies';
 import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
+import Register from './pages/Register';
+import Verify from './pages/Verify';
+import RequestReset from './pages/RequestReset';
+import ResetPassword from './pages/ResetPassword';
 import Votaciones from './pages/Votaciones';
 import ManageAssistants from './pages/ManageAssistants';
 import ManageUsers from './pages/ManageUsers';
 import ManageElectionUsers from './pages/ManageElectionUsers';
 import AuditLogs from './pages/AuditLogs';
+import EditElection from './pages/EditElection';
 import { ToastProvider } from './components/ui/toast';
 
 const queryClient = new QueryClient();
@@ -26,8 +31,12 @@ const App: React.FC = () => {
           <Router>
             <Routes>
               <Route path="/login" element={<Login />} />
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}>
-                <Route element={<Layout />}>
+              <Route path="/register" element={<Register />} />
+              <Route path="/verify" element={<Verify />} />
+              <Route path="/reset-password" element={<RequestReset />} />
+              <Route path="/reset-password/:token" element={<ResetPassword />} />
+              <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}> 
+                <Route element={<Layout />}> 
                   <Route path="/votaciones" element={<Votaciones />} />
                 </Route>
               </Route>
@@ -36,14 +45,15 @@ const App: React.FC = () => {
                   <Route path="/votaciones/:id/attendance" element={<Asistencia />} />
                 </Route>
               </Route>
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}>
-                <Route element={<Layout />}>
+              <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}> 
+                <Route element={<Layout />}> 
                   <Route path="/votaciones/:id/upload" element={<UploadShareholders />} />
                   <Route path="/votaciones/:id/proxies" element={<Proxies />} />
                   <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} />
                   <Route path="/votaciones/:id/audit" element={<AuditLogs />} />
                   <Route path="/users" element={<ManageUsers />} />
                   <Route path="/votaciones/:id/users" element={<ManageElectionUsers />} />
+                  <Route path="/votaciones/:id/edit" element={<EditElection />} />
                 </Route>
               </Route>
               <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}>

--- a/frontend/src/hooks/useUpdateElection.ts
+++ b/frontend/src/hooks/useUpdateElection.ts
@@ -10,6 +10,13 @@ interface Payload {
   registration_end?: string;
   attendance_registrars?: number[];
   vote_registrars?: number[];
+  questions?: {
+    text: string;
+    type: string;
+    required: boolean;
+    order: number;
+    options: { text: string; value: string }[];
+  }[];
 }
 
 export const useUpdateElection = (

--- a/frontend/src/pages/EditElection.tsx
+++ b/frontend/src/pages/EditElection.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Card from '../components/ui/card';
+import Input from '../components/ui/input';
+import Button from '../components/ui/button';
+import QuestionBuilder, { QuestionDraft } from '../components/QuestionBuilder';
+import { useUpdateElection } from '../hooks/useUpdateElection';
+import { apiFetch } from '../lib/api';
+import { useToast } from '../components/ui/toast';
+
+const EditElection: React.FC = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+  const [questions, setQuestions] = useState<QuestionDraft[]>([]);
+
+  useEffect(() => {
+    if (!id) return;
+    apiFetch<any>(`/elections/${id}`).then((e) => {
+      setName(e.name);
+      setDate(e.date.slice(0, 10));
+    });
+    apiFetch<any[]>(`/elections/${id}/questions`).then((qs) => {
+      setQuestions(
+        qs.map((q) => ({
+          text: q.text,
+          type: q.type,
+          required: q.required,
+          options: q.options?.map((o: any) => o.text) || [],
+        }))
+      );
+    });
+  }, [id]);
+
+  const { mutate, isLoading } = useUpdateElection(
+    () => {
+      toast('Votación actualizada');
+      navigate('/votaciones');
+    },
+    (err) => toast(err.message)
+  );
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutate({
+      id: Number(id),
+      name,
+      date,
+      questions: questions.map((q, i) => ({
+        text: q.text,
+        type: q.type,
+        required: q.required,
+        order: i,
+        options: q.options.map((o, oi) => ({ text: o, value: String(oi) })),
+      })),
+    });
+  };
+
+  return (
+    <div className="p-4">
+      <Card className="p-4 max-w-xl mx-auto">
+        <form onSubmit={onSubmit} className="space-y-4">
+          <h1 className="text-lg font-semibold">Editar votación</h1>
+          <div>
+            <label className="block text-sm mb-1">Nombre</label>
+            <Input value={name} onChange={(e) => setName(e.target.value)} required />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Fecha</label>
+            <Input type="date" value={date} onChange={(e) => setDate(e.target.value)} required />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Preguntas</label>
+            <QuestionBuilder questions={questions} setQuestions={setQuestions} />
+          </div>
+          <div className="flex space-x-2">
+            <Button type="submit" disabled={isLoading}>Guardar</Button>
+            <Button type="button" variant="outline" onClick={() => navigate('/votaciones')}>
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+};
+
+export default EditElection;

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,34 +1,28 @@
 import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useMutation } from '../lib/react-query';
-import { useAuth } from '../context/AuthContext';
 import { apiFetch } from '../lib/api';
 import Input from '../components/ui/input';
 import Button from '../components/ui/button';
 import Card from '../components/ui/card';
 
-const Login: React.FC = () => {
+const Register: React.FC = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [token, setToken] = useState('');
   const [error, setError] = useState('');
-  const navigate = useNavigate();
-  const { login } = useAuth();
 
   const mutation = useMutation({
-    mutationFn: async (vars: { username: string; password: string }) => {
-      return apiFetch('/auth/login', {
+    mutationFn: (vars: { username: string; password: string }) =>
+      apiFetch('/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(vars),
-      });
+      }),
+    onSuccess: (data: any) => {
+      setToken(data.verification_token);
     },
-    onSuccess: (data) => {
-      login(data.access_token, data.role, data.username);
-      navigate('/votaciones');
-    },
-    onError: (err: any) => {
-      setError(err.message);
-    },
+    onError: (err: any) => setError(err.message),
   });
 
   const onSubmit = (e: React.FormEvent) => {
@@ -41,7 +35,7 @@ const Login: React.FC = () => {
     <div className="min-vh-100 d-flex align-items-center justify-content-center bg-light p-4">
       <Card className="p-4 w-100" style={{ maxWidth: '24rem' }}>
         <form onSubmit={onSubmit} className="d-flex flex-column gap-3">
-          <h1 className="h4 text-center">Ingreso</h1>
+          <h1 className="h4 text-center">Registro</h1>
           {error && (
             <p role="alert" className="text-primary text-center">
               {error}
@@ -53,11 +47,9 @@ const Login: React.FC = () => {
             </label>
             <Input
               id="username"
-              type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
-              autoComplete="username"
             />
           </div>
           <div>
@@ -70,18 +62,19 @@ const Login: React.FC = () => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              autoComplete="current-password"
             />
           </div>
           <Button type="submit" className="w-100" disabled={mutation.isLoading}>
-            {mutation.isLoading ? 'Ingresando…' : 'Ingresar'}
+            {mutation.isLoading ? 'Registrando…' : 'Registrar'}
           </Button>
+          {token && (
+            <p className="text-sm text-center break-all">
+              Token de verificación: {token}
+            </p>
+          )}
           <div className="text-center text-sm">
-            <Link to="/register" className="text-primary me-2">
-              Registrarse
-            </Link>
-            <Link to="/reset-password" className="text-primary">
-              ¿Olvidaste tu contraseña?
+            <Link to="/login" className="text-primary">
+              Volver al ingreso
             </Link>
           </div>
         </form>
@@ -90,4 +83,4 @@ const Login: React.FC = () => {
   );
 };
 
-export default Login;
+export default Register;

--- a/frontend/src/pages/RequestReset.tsx
+++ b/frontend/src/pages/RequestReset.tsx
@@ -1,47 +1,40 @@
 import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useMutation } from '../lib/react-query';
-import { useAuth } from '../context/AuthContext';
 import { apiFetch } from '../lib/api';
 import Input from '../components/ui/input';
 import Button from '../components/ui/button';
 import Card from '../components/ui/card';
 
-const Login: React.FC = () => {
+const RequestReset: React.FC = () => {
   const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const [token, setToken] = useState('');
   const [error, setError] = useState('');
-  const navigate = useNavigate();
-  const { login } = useAuth();
 
   const mutation = useMutation({
-    mutationFn: async (vars: { username: string; password: string }) => {
-      return apiFetch('/auth/login', {
+    mutationFn: (vars: { username: string }) =>
+      apiFetch('/auth/request-reset', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(vars),
-      });
+      }),
+    onSuccess: (data: any) => {
+      setToken(data.reset_token);
     },
-    onSuccess: (data) => {
-      login(data.access_token, data.role, data.username);
-      navigate('/votaciones');
-    },
-    onError: (err: any) => {
-      setError(err.message);
-    },
+    onError: (err: any) => setError(err.message),
   });
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    mutation.mutate({ username, password });
+    mutation.mutate({ username });
   };
 
   return (
     <div className="min-vh-100 d-flex align-items-center justify-content-center bg-light p-4">
       <Card className="p-4 w-100" style={{ maxWidth: '24rem' }}>
         <form onSubmit={onSubmit} className="d-flex flex-column gap-3">
-          <h1 className="h4 text-center">Ingreso</h1>
+          <h1 className="h4 text-center">Recuperar contraseña</h1>
           {error && (
             <p role="alert" className="text-primary text-center">
               {error}
@@ -53,35 +46,22 @@ const Login: React.FC = () => {
             </label>
             <Input
               id="username"
-              type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
-              autoComplete="username"
-            />
-          </div>
-          <div>
-            <label htmlFor="password" className="form-label">
-              Contraseña
-            </label>
-            <Input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              autoComplete="current-password"
             />
           </div>
           <Button type="submit" className="w-100" disabled={mutation.isLoading}>
-            {mutation.isLoading ? 'Ingresando…' : 'Ingresar'}
+            {mutation.isLoading ? 'Enviando…' : 'Enviar'}
           </Button>
+          {token && (
+            <p className="text-sm text-center break-all">
+              Token de reinicio: {token}
+            </p>
+          )}
           <div className="text-center text-sm">
-            <Link to="/register" className="text-primary me-2">
-              Registrarse
-            </Link>
-            <Link to="/reset-password" className="text-primary">
-              ¿Olvidaste tu contraseña?
+            <Link to="/login" className="text-primary">
+              Volver al ingreso
             </Link>
           </div>
         </form>
@@ -90,4 +70,4 @@ const Login: React.FC = () => {
   );
 };
 
-export default Login;
+export default RequestReset;

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,68 +1,61 @@
 import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useMutation } from '../lib/react-query';
-import { useAuth } from '../context/AuthContext';
 import { apiFetch } from '../lib/api';
 import Input from '../components/ui/input';
 import Button from '../components/ui/button';
 import Card from '../components/ui/card';
 
-const Login: React.FC = () => {
-  const [username, setUsername] = useState('');
+const ResetPassword: React.FC = () => {
+  const { token: paramToken } = useParams();
+  const [token, setToken] = useState(paramToken || '');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const { login } = useAuth();
 
   const mutation = useMutation({
-    mutationFn: async (vars: { username: string; password: string }) => {
-      return apiFetch('/auth/login', {
+    mutationFn: (vars: { token: string; new_password: string }) =>
+      apiFetch('/auth/reset-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(vars),
-      });
+      }),
+    onSuccess: () => {
+      navigate('/login');
     },
-    onSuccess: (data) => {
-      login(data.access_token, data.role, data.username);
-      navigate('/votaciones');
-    },
-    onError: (err: any) => {
-      setError(err.message);
-    },
+    onError: (err: any) => setError(err.message),
   });
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    mutation.mutate({ username, password });
+    mutation.mutate({ token, new_password: password });
   };
 
   return (
     <div className="min-vh-100 d-flex align-items-center justify-content-center bg-light p-4">
       <Card className="p-4 w-100" style={{ maxWidth: '24rem' }}>
         <form onSubmit={onSubmit} className="d-flex flex-column gap-3">
-          <h1 className="h4 text-center">Ingreso</h1>
+          <h1 className="h4 text-center">Restablecer contraseña</h1>
           {error && (
             <p role="alert" className="text-primary text-center">
               {error}
             </p>
           )}
           <div>
-            <label htmlFor="username" className="form-label">
-              Usuario
+            <label htmlFor="token" className="form-label">
+              Token
             </label>
             <Input
-              id="username"
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              id="token"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
               required
-              autoComplete="username"
             />
           </div>
           <div>
             <label htmlFor="password" className="form-label">
-              Contraseña
+              Nueva contraseña
             </label>
             <Input
               id="password"
@@ -70,18 +63,14 @@ const Login: React.FC = () => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              autoComplete="current-password"
             />
           </div>
           <Button type="submit" className="w-100" disabled={mutation.isLoading}>
-            {mutation.isLoading ? 'Ingresando…' : 'Ingresar'}
+            {mutation.isLoading ? 'Guardando…' : 'Guardar'}
           </Button>
           <div className="text-center text-sm">
-            <Link to="/register" className="text-primary me-2">
-              Registrarse
-            </Link>
-            <Link to="/reset-password" className="text-primary">
-              ¿Olvidaste tu contraseña?
+            <Link to="/login" className="text-primary">
+              Volver al ingreso
             </Link>
           </div>
         </form>
@@ -90,4 +79,4 @@ const Login: React.FC = () => {
   );
 };
 
-export default Login;
+export default ResetPassword;

--- a/frontend/src/pages/Verify.tsx
+++ b/frontend/src/pages/Verify.tsx
@@ -1,47 +1,41 @@
 import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useMutation } from '../lib/react-query';
-import { useAuth } from '../context/AuthContext';
 import { apiFetch } from '../lib/api';
 import Input from '../components/ui/input';
 import Button from '../components/ui/button';
 import Card from '../components/ui/card';
 
-const Login: React.FC = () => {
+const Verify: React.FC = () => {
   const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const [token, setToken] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const { login } = useAuth();
 
   const mutation = useMutation({
-    mutationFn: async (vars: { username: string; password: string }) => {
-      return apiFetch('/auth/login', {
+    mutationFn: (vars: { username: string; token: string }) =>
+      apiFetch('/auth/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(vars),
-      });
+      }),
+    onSuccess: () => {
+      navigate('/login');
     },
-    onSuccess: (data) => {
-      login(data.access_token, data.role, data.username);
-      navigate('/votaciones');
-    },
-    onError: (err: any) => {
-      setError(err.message);
-    },
+    onError: (err: any) => setError(err.message),
   });
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    mutation.mutate({ username, password });
+    mutation.mutate({ username, token });
   };
 
   return (
     <div className="min-vh-100 d-flex align-items-center justify-content-center bg-light p-4">
       <Card className="p-4 w-100" style={{ maxWidth: '24rem' }}>
         <form onSubmit={onSubmit} className="d-flex flex-column gap-3">
-          <h1 className="h4 text-center">Ingreso</h1>
+          <h1 className="h4 text-center">Verificar cuenta</h1>
           {error && (
             <p role="alert" className="text-primary text-center">
               {error}
@@ -53,35 +47,28 @@ const Login: React.FC = () => {
             </label>
             <Input
               id="username"
-              type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
-              autoComplete="username"
             />
           </div>
           <div>
-            <label htmlFor="password" className="form-label">
-              Contraseña
+            <label htmlFor="token" className="form-label">
+              Token
             </label>
             <Input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              id="token"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
               required
-              autoComplete="current-password"
             />
           </div>
           <Button type="submit" className="w-100" disabled={mutation.isLoading}>
-            {mutation.isLoading ? 'Ingresando…' : 'Ingresar'}
+            {mutation.isLoading ? 'Verificando…' : 'Verificar'}
           </Button>
           <div className="text-center text-sm">
-            <Link to="/register" className="text-primary me-2">
-              Registrarse
-            </Link>
-            <Link to="/reset-password" className="text-primary">
-              ¿Olvidaste tu contraseña?
+            <Link to="/login" className="text-primary">
+              Volver al ingreso
             </Link>
           </div>
         </form>
@@ -90,4 +77,4 @@ const Login: React.FC = () => {
   );
 };
 
-export default Login;
+export default Verify;


### PR DESCRIPTION
## Summary
- allow elections to update their questions
- add registration, verification and password reset UIs
- enable editing elections and questions from a dedicated page

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a66071e4b08322826f4591ce0f77dd