### PR TITLE
feat: integrate observer and voting modules in frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import ManageElectionUsers from './pages/ManageElectionUsers';
 import AuditLogs from './pages/AuditLogs';
 import EditElection from './pages/EditElection';
 import CreateElectionWizard from './pages/CreateElectionWizard';
+import Observer from './pages/Observer';
+import Ballots from './pages/Ballots';
 import { ToastProvider } from './components/ui/toast';
 
 const queryClient = new QueryClient();
@@ -38,8 +40,8 @@ const App: React.FC = () => {
               <Route path="/reset-password/:token" element={<ResetPassword />} />
               <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}> 
                 <Route element={<Layout />}> 
-                  <Route path="/votaciones" element={<Votaciones />} />
-                </Route>
+                  <Route path="/votaciones" element={<Votaciones />} /> 
+                </Route> 
               </Route>
               <Route element={<ProtectedRoute roles={["FUNCIONAL_BVG", "ADMIN_BVG"]} />}>
                 <Route element={<Layout />}>
@@ -58,10 +60,12 @@ const App: React.FC = () => {
                   <Route path="/votaciones/:id/edit" element={<EditElection />} />
                 </Route>
               </Route>
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}>
-                <Route element={<Layout />}>
-                  <Route path="/votaciones/:id/dashboard" element={<Dashboard />} />
-                </Route>
+              <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}> 
+                <Route element={<Layout />}> 
+                  <Route path="/votaciones/:id/dashboard" element={<Dashboard />} /> 
+                  <Route path="/votaciones/:id/observer" element={<Observer />} />
+                  <Route path="/votaciones/:id/ballots" element={<Ballots />} />
+                </Route> 
               </Route>
               <Route path="/" element={<Navigate to="/login" replace />} />
               <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/hooks/useBallots.ts
+++ b/frontend/src/hooks/useBallots.ts
@@ -1,0 +1,47 @@
+import { useQuery, useMutation, useQueryClient } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+export interface Ballot {
+  id: number;
+  election_id: number;
+  title: string;
+}
+
+export interface OptionResult {
+  id: number;
+  ballot_id: number;
+  text: string;
+  votes: number;
+}
+
+export const useBallots = (electionId: number) => {
+  return useQuery<Ballot[]>({
+    queryKey: ['ballots', electionId],
+    queryFn: () => apiFetch<Ballot[]>(`/elections/${electionId}/ballots`),
+  });
+};
+
+export const useBallotResults = (ballotId: number, enabled = true) => {
+  return useQuery<OptionResult[]>({
+    queryKey: ['ballot-results', ballotId],
+    queryFn: () => apiFetch<OptionResult[]>(`/ballots/${ballotId}/results`),
+    enabled,
+  });
+};
+
+export const useCastVote = (ballotId: number, onSuccess?: () => void) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { option_id: number }) =>
+      apiFetch(`/ballots/${ballotId}/vote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['ballot-results', ballotId] });
+      onSuccess?.();
+    },
+  });
+};
+

--- a/frontend/src/hooks/useObserver.ts
+++ b/frontend/src/hooks/useObserver.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '../lib/react-query';
+import { apiFetch } from '../lib/api';
+
+export interface ObserverRow {
+  code: string;
+  name: string;
+  estado: string;
+  apoderado?: string | null;
+  acciones_propias: number;
+  acciones_representadas: number;
+  total_quorum: number;
+}
+
+export const useObserver = (electionId: number) => {
+  return useQuery<ObserverRow[]>({
+    queryKey: ['observer', electionId],
+    queryFn: () => apiFetch<ObserverRow[]>(`/elections/${electionId}/observer`),
+  });
+};
+

--- a/frontend/src/pages/Ballots.tsx
+++ b/frontend/src/pages/Ballots.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  useBallots,
+  useBallotResults,
+  useCastVote,
+} from '../hooks/useBallots';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../components/ui/table';
+import Button from '../components/ui/button';
+import { useToast } from '../components/ui/toast';
+
+const Ballots: React.FC = () => {
+  const { id } = useParams();
+  const electionId = Number(id);
+  const { data: ballots, isLoading, error } = useBallots(electionId);
+  const [selected, setSelected] = useState<number | null>(null);
+  const { data: results } = useBallotResults(selected || 0, !!selected);
+  const toast = useToast();
+  const castVote = useCastVote(selected || 0, () => toast('Voto registrado'));
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Boletas</h1>
+      {isLoading && <p>Cargando...</p>}
+      {error && (
+        <p role="alert" className="text-body">
+          Error al cargar boletas
+        </p>
+      )}
+      {ballots && (
+        <ul className="space-y-2">
+          {ballots.map((b) => (
+            <li key={b.id}>
+              <button className="underline" onClick={() => setSelected(b.id)}>
+                {b.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {results && selected && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Opción</TableHead>
+              <TableHead>Votos</TableHead>
+              <TableHead></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {results.map((r) => (
+              <TableRow key={r.id}>
+                <TableCell>{r.text}</TableCell>
+                <TableCell>{r.votes}</TableCell>
+                <TableCell>
+                  <Button
+                    variant="outline"
+                    onClick={() => castVote.mutate({ option_id: r.id })}
+                  >
+                    Votar
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+};
+
+export default Ballots;
+

--- a/frontend/src/pages/Observer.tsx
+++ b/frontend/src/pages/Observer.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useObserver } from '../hooks/useObserver';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../components/ui/table';
+
+const Observer: React.FC = () => {
+  const { id } = useParams();
+  const electionId = Number(id);
+  const { data: rows, isLoading, error } = useObserver(electionId);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Observador</h1>
+      {isLoading && <p>Cargando...</p>}
+      {error && (
+        <p role="alert" className="text-body">
+          Error al cargar observación
+        </p>
+      )}
+      {rows && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Código</TableHead>
+              <TableHead>Nombre</TableHead>
+              <TableHead>Estado</TableHead>
+              <TableHead>Apoderado</TableHead>
+              <TableHead>Acciones propias</TableHead>
+              <TableHead>Acciones representadas</TableHead>
+              <TableHead>Total quorum</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((r) => (
+              <TableRow key={r.code}>
+                <TableCell>{r.code}</TableCell>
+                <TableCell>{r.name}</TableCell>
+                <TableCell>{r.estado}</TableCell>
+                <TableCell>{r.apoderado || '-'}</TableCell>
+                <TableCell>{r.acciones_propias}</TableCell>
+                <TableCell>{r.acciones_representadas}</TableCell>
+                <TableCell>{r.total_quorum}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+};
+
+export default Observer;
+

--- a/frontend/src/pages/Votaciones.tsx
+++ b/frontend/src/pages/Votaciones.tsx
@@ -118,6 +118,18 @@ const Votaciones: React.FC = () => {
                           >
                             Roles
                           </Button>
+                          <Button
+                            variant="outline"
+                            onClick={() => navigate(`/votaciones/${e.id}/observer`)}
+                          >
+                            Observador
+                          </Button>
+                          <Button
+                            variant="outline"
+                            onClick={() => navigate(`/votaciones/${e.id}/ballots`)}
+                          >
+                            Boletas
+                          </Button>
                           {!open && <span className="text-sm text-gray-500">Bloqueada</span>}
                           <Button
                             variant="outline"
@@ -147,6 +159,18 @@ const Votaciones: React.FC = () => {
                               Gestionar votos
                             </Button>
                           )}
+                          <Button
+                            variant="outline"
+                            onClick={() => navigate(`/votaciones/${e.id}/observer`)}
+                          >
+                            Observador
+                          </Button>
+                          <Button
+                            variant="outline"
+                            onClick={() => navigate(`/votaciones/${e.id}/ballots`)}
+                          >
+                            Boletas
+                          </Button>
                           {!open && <span className="text-sm text-gray-500">Bloqueada</span>}
                         </>
                       )}


### PR DESCRIPTION
## Summary
- add hooks and pages for observer table and ballots
- wire routes and navigation for observer and voting modules

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a6848dc3dc8322a9625055f6508d26