### PR TITLE
feat: manage attendee registry templates and documents

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -177,6 +177,9 @@ class AuditLog(Base):
 
 class Attendee(Base):
     __tablename__ = "attendees"
+    __table_args__ = (
+        UniqueConstraint("election_id", "identifier", name="uix_attendee_identifier"),
+    )
     id = Column(Integer, primary_key=True)
     election_id = Column(Integer, index=True, nullable=False)
     identifier = Column(String, nullable=False)
@@ -184,6 +187,7 @@ class Attendee(Base):
     representante = Column(String)
     apoderado = Column(String)
     acciones = Column(DECIMAL, nullable=False, default=0)
+    apoderado_pdf_url = Column(String)
 
 
 class QuestionType(str, enum.Enum):

--- a/backend/app/routers/assistants.py
+++ b/backend/app/routers/assistants.py
@@ -2,8 +2,12 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 from typing import List
 import csv
-from io import StringIO
-from openpyxl import load_workbook
+from io import StringIO, BytesIO
+from pathlib import Path
+from openpyxl import load_workbook, Workbook
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Request
+from fastapi.responses import Response
 
 from .. import models, schemas, database
 from ..security import get_current_user, require_role
@@ -19,6 +23,28 @@ def get_db():
         db.close()
 
 
+@router.get("/template", dependencies=[require_role(["FUNCIONAL_BVG", "ADMIN_BVG"])] )
+def export_template(format: str = "csv"):
+    headers = ["id", "accionista", "representante_legal", "apoderado", "acciones"]
+    if format == "xlsx":
+        wb = Workbook()
+        ws = wb.active
+        ws.append(headers)
+        bio = BytesIO()
+        wb.save(bio)
+        return Response(
+            content=bio.getvalue(),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            headers={"Content-Disposition": "attachment; filename=padron_template.xlsx"},
+        )
+    else:
+        content = ",".join(headers) + "\n"
+        return Response(
+            content=content,
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=padron_template.csv"},
+        )
+
 @router.post(
     "/import-excel",
     response_model=List[schemas.Attendee],
@@ -30,20 +56,51 @@ def import_attendees_excel(
     db: Session = Depends(get_db),
     current_user = Depends(get_current_user),
 ):
-    required = {"id", "accionista", "representante", "apoderado", "acciones"}
+    required = {"id", "accionista", "representante_legal", "apoderado", "acciones"}
     results: List[models.Attendee] = []
+    errors: List[str] = []
+    seen_ids = set(
+        a.identifier
+        for a in db.query(models.Attendee.identifier).filter_by(election_id=election_id)
+    )
 
-    def process_row(row: dict):
+    def process_row(row: dict, idx: int):
+        row_errors = []
+        identifier = str(row.get("id", "")).strip()
+        if not identifier:
+            row_errors.append("id required")
+        elif identifier in seen_ids:
+            row_errors.append("duplicate id")
+        accionista = (row.get("accionista") or "").strip()
+        if not accionista:
+            row_errors.append("accionista required")
+        acciones_raw = row.get("acciones")
+        try:
+            acciones_val = float(acciones_raw)
+            if acciones_val <= 0:
+                row_errors.append("acciones must be positive")
+        except Exception:
+            row_errors.append("acciones must be numeric")
+
+        representante = (row.get("representante_legal") or None)
+        apoderado = (row.get("apoderado") or None)
+
+        if row_errors:
+            errors.append(f"Row {idx}: {', '.join(row_errors)}")
+            return
+
         attendee = models.Attendee(
             election_id=election_id,
-            identifier=str(row.get("id", "")),
-            accionista=row.get("accionista", ""),
-            representante=row.get("representante"),
-            apoderado=row.get("apoderado"),
-            acciones=float(row.get("acciones") or 0),
+            identifier=identifier,
+            accionista=accionista,
+            representante=representante,
+            apoderado=apoderado,
+            acciones=acciones_val,
         )
         db.add(attendee)
         results.append(attendee)
+        seen_ids.add(identifier)
+
         # Sync with shareholders/attendance so registrars can see attendees
         sh = (
             db.query(models.Shareholder)
@@ -87,9 +144,9 @@ def import_attendees_excel(
                 status_code=400,
                 detail=f"Missing columns: {', '.join(sorted(missing))}",
             )
-        for data_row in rows[1:]:
+        for idx, data_row in enumerate(rows[1:], start=2):
             row = dict(zip(headers, data_row))
-            process_row(row)
+            process_row(row, idx)
     else:
         content = file.file.read().decode("utf-8")
         reader = csv.DictReader(StringIO(content))
@@ -98,12 +155,21 @@ def import_attendees_excel(
             raise HTTPException(
                 status_code=400, detail=f"Missing columns: {', '.join(sorted(missing))}"
             )
-        for row in reader:
-            process_row(row)
+        for idx, row in enumerate(reader, start=2):
+            process_row(row, idx)
+
+    if errors:
+        raise HTTPException(status_code=400, detail=errors)
+
     db.commit()
+    output: List[schemas.Attendee] = []
     for att in results:
         db.refresh(att)
-    return results
+        data = schemas.Attendee.model_validate(att).model_dump()
+        data["requires_document"] = bool(att.apoderado)
+        data["document_uploaded"] = bool(att.apoderado_pdf_url)
+        output.append(schemas.Attendee(**data))
+    return output
 
 
 @router.get(
@@ -112,7 +178,14 @@ def import_attendees_excel(
     dependencies=[require_role(["FUNCIONAL_BVG", "ADMIN_BVG"])]
 )
 def list_attendees(election_id: int, db: Session = Depends(get_db)):
-    return db.query(models.Attendee).filter_by(election_id=election_id).all()
+    attendees = db.query(models.Attendee).filter_by(election_id=election_id).all()
+    result: List[schemas.Attendee] = []
+    for att in attendees:
+        data = schemas.Attendee.model_validate(att).model_dump()
+        data["requires_document"] = bool(att.apoderado)
+        data["document_uploaded"] = bool(att.apoderado_pdf_url)
+        result.append(schemas.Attendee(**data))
+    return result
 
 
 @router.get(
@@ -128,7 +201,10 @@ def get_attendee(
     attendee = db.query(models.Attendee).filter_by(id=attendee_id, election_id=election_id).first()
     if not attendee:
         raise HTTPException(status_code=404, detail="attendee not found")
-    return attendee
+    data = schemas.Attendee.model_validate(attendee).model_dump()
+    data["requires_document"] = bool(attendee.apoderado)
+    data["document_uploaded"] = bool(attendee.apoderado_pdf_url)
+    return schemas.Attendee(**data)
 
 
 @router.put(
@@ -146,10 +222,15 @@ def update_attendee(
     if not attendee:
         raise HTTPException(status_code=404, detail="attendee not found")
     for field, value in payload.model_dump(exclude_unset=True).items():
+        if field == "apoderado" and not value:
+            attendee.apoderado_pdf_url = None
         setattr(attendee, field, value)
     db.commit()
     db.refresh(attendee)
-    return attendee
+    data = schemas.Attendee.model_validate(attendee).model_dump()
+    data["requires_document"] = bool(attendee.apoderado)
+    data["document_uploaded"] = bool(attendee.apoderado_pdf_url)
+    return schemas.Attendee(**data)
 
 
 @router.delete(
@@ -168,3 +249,38 @@ def delete_attendee(
     db.delete(attendee)
     db.commit()
 
+
+@router.post(
+    "/{attendee_id}/apoderado-pdf",
+    response_model=schemas.Attendee,
+    dependencies=[require_role(["FUNCIONAL_BVG", "ADMIN_BVG"])]
+)
+async def upload_apoderado_pdf(
+    election_id: int,
+    attendee_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    attendee = db.query(models.Attendee).filter_by(id=attendee_id, election_id=election_id).first()
+    if not attendee:
+        raise HTTPException(status_code=404, detail="attendee not found")
+    if not attendee.apoderado:
+        raise HTTPException(status_code=400, detail="attendee has no apoderado")
+    if attendee.apoderado_pdf_url:
+        raise HTTPException(status_code=400, detail="document already uploaded")
+    if file.content_type != "application/pdf":
+        raise HTTPException(status_code=400, detail="invalid file type")
+    content = await file.read()
+    storage_dir = Path("storage") / str(election_id) / "apoderados"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    file_path = storage_dir / f"{attendee.id}.pdf"
+    with open(file_path, "wb") as f:
+        f.write(content)
+    attendee.apoderado_pdf_url = str(file_path)
+    db.commit()
+    db.refresh(attendee)
+    data = schemas.Attendee.model_validate(attendee).model_dump()
+    data["requires_document"] = True
+    data["document_uploaded"] = True
+    return schemas.Attendee(**data)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -289,6 +289,9 @@ class AttendeeUpdate(BaseModel):
 class Attendee(AttendeeBase):
     id: int
     election_id: int
+    apoderado_pdf_url: Optional[str] = None
+    requires_document: bool = False
+    document_uploaded: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- allow exporting attendee template in CSV or Excel
- add validation and document tracking to attendee import
- support uploading apoderado PDF documents after import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a7286630848322a0836cc1b96697e4