### PR TITLE
Fix election creation missing description

### DIFF
--- a/frontend/src/hooks/useCreateElection.ts
+++ b/frontend/src/hooks/useCreateElection.ts
@@ -4,6 +4,7 @@ import { Election } from './useElections';
 
 interface Payload {
   name: string;
+  description?: string;
   date: string;
   registration_start?: string;
   registration_end?: string;

--- a/frontend/src/pages/CreateElectionWizard.tsx
+++ b/frontend/src/pages/CreateElectionWizard.tsx
@@ -103,6 +103,7 @@ const CreateElectionWizard: React.FC = () => {
     try {
       const payload: any = {
         name,
+        description,
         date,
         ...(openDate ? { registration_start: new Date(openDate).toISOString() } : {}),
         ...(closeDate ? { registration_end: new Date(closeDate).toISOString() } : {}),


### PR DESCRIPTION
## Summary
- send description when creating elections
- allow description field in useCreateElection payload

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a748b66e50832299a949e90d57bcf2