### PR TITLE
Connect submit button and handle errors

### DIFF
--- a/frontend/src/pages/CreateElectionWizard.tsx
+++ b/frontend/src/pages/CreateElectionWizard.tsx
@@ -54,13 +54,10 @@ const CreateElectionWizard: React.FC = () => {
   // Step 4 - ballot
   const [questions, setQuestions] = useState<QuestionDraft[]>([]);
 
-  const { mutateAsync, isLoading } = useCreateElection(
-    () => {
-      toast('Votación creada');
-      navigate('/votaciones');
-    },
-    (err) => toast(err.message)
-  );
+  const { mutateAsync, isLoading } = useCreateElection(() => {
+    toast('Votación creada');
+    navigate('/votaciones');
+  });
 
   const filteredUsers = users?.filter((u) =>
     u.username.toLowerCase().includes(userSearch.toLowerCase())
@@ -98,7 +95,7 @@ const CreateElectionWizard: React.FC = () => {
 
   const prev = () => setStep(step - 1);
 
-  const handleCreate = async () => {
+  const handleSubmit = async () => {
     if (!validateStep()) return;
     try {
       const payload: any = {
@@ -121,8 +118,8 @@ const CreateElectionWizard: React.FC = () => {
       if (shImport.file && shImport.previewData.length > 0) {
         await shImport.upload(election.id);
       }
-    } catch (e) {
-      // error handled in hook
+    } catch (e: any) {
+      toast(e.message);
     }
   };
 
@@ -302,7 +299,7 @@ const CreateElectionWizard: React.FC = () => {
             </Button>
           )}
           {step === 5 && (
-            <Button type="button" onClick={handleCreate} disabled={isLoading}>
+            <Button type="button" onClick={handleSubmit} disabled={isLoading}>
               {isLoading ? 'Creando…' : 'Crear votación'}
             </Button>
           )}


### PR DESCRIPTION
## Summary
- Wire create election button to submit handler
- Validate steps and trigger mutate with toast on errors

## Testing
- `cd frontend && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68a74dd3b2a48322b265bc4ea4ac7b68