### PR TITLE
Connect submit button and handle errors

### DIFF
--- a/frontend/src/hooks/useCreateElection.ts
+++ b/frontend/src/hooks/useCreateElection.ts
@@ -27,8 +27,7 @@ export const useCreateElection = (
     mutationFn: (payload) =>
       apiFetch('/elections', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: payload,
       }),
     onSuccess: () => {
       onSuccess?.();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,8 +6,15 @@ export async function apiFetch<T = any>(path: string, init: RequestInit = {}): P
   const headers: HeadersInit = {
     ...(init.headers || {}),
   };
+  let body = init.body as any;
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const res = await fetch(base + path, { ...init, headers });
+
+  if (body && !(body instanceof FormData) && typeof body === 'object') {
+    headers['Content-Type'] = headers['Content-Type'] || 'application/json';
+    body = JSON.stringify(body);
+  }
+
+  const res = await fetch(base + path, { ...init, headers, body });
   if (!res.ok) {
     let message = res.statusText;
     try {

--- a/frontend/src/lib/react-query.tsx
+++ b/frontend/src/lib/react-query.tsx
@@ -52,15 +52,17 @@ export const useMutation = <TData = any, TVariables = any>(config: MutationConfi
       setLoading(true);
       const data = await config.mutationFn(vars);
       config.onSuccess?.(data);
+      return data;
     } catch (err: any) {
       toast(err.message || 'Error');
       config.onError?.(err);
+      throw err;
     } finally {
       setLoading(false);
     }
   };
 
-  return { mutate, isLoading };
+  return { mutate, mutateAsync: mutate, isLoading };
 };
 
 interface QueryConfig<TData> {

--- a/frontend/src/pages/CreateElectionWizard.tsx
+++ b/frontend/src/pages/CreateElectionWizard.tsx
@@ -54,13 +54,10 @@ const CreateElectionWizard: React.FC = () => {
   // Step 4 - ballot
   const [questions, setQuestions] = useState<QuestionDraft[]>([]);
 
-  const { mutateAsync, isLoading } = useCreateElection(
-    () => {
-      toast('Votación creada');
-      navigate('/votaciones');
-    },
-    (err) => toast(err.message)
-  );
+  const { mutateAsync, isLoading } = useCreateElection(() => {
+    toast('Votación creada');
+    navigate('/votaciones');
+  });
 
   const filteredUsers = users?.filter((u) =>
     u.username.toLowerCase().includes(userSearch.toLowerCase())
@@ -98,7 +95,7 @@ const CreateElectionWizard: React.FC = () => {
 
   const prev = () => setStep(step - 1);
 
-  const handleCreate = async () => {
+  const handleSubmit = async () => {
     if (!validateStep()) return;
     try {
       const payload: any = {
@@ -122,7 +119,7 @@ const CreateElectionWizard: React.FC = () => {
         await shImport.upload(election.id);
       }
     } catch (e) {
-      // error handled in hook
+      // error handled in useMutation
     }
   };
 
@@ -302,7 +299,7 @@ const CreateElectionWizard: React.FC = () => {
             </Button>
           )}
           {step === 5 && (
-            <Button type="button" onClick={handleCreate} disabled={isLoading}>
+            <Button type="button" onClick={handleSubmit} disabled={isLoading}>
               {isLoading ? 'Creando…' : 'Crear votación'}
             </Button>
           )}


### PR DESCRIPTION
## Summary
- Wire create election button to submit handler
- Validate steps and trigger mutate with toast on errors
- Fix create election mutation and auto JSON encoding

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a74dd3b2a48322b265bc4ea4ac7b68