### PR TITLE
feat: mejorar registro de asistencia

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -40,6 +40,10 @@ class Shareholder(ShareholderBase):
 
 class ShareholderWithAttendance(Shareholder):
     attendance_mode: Optional[AttendanceMode] = None
+    representante: Optional[str] = None
+    apoderado: Optional[str] = None
+    attendee_id: Optional[int] = None
+    apoderado_pdf: bool = False
 
 
 class AttendanceBase(BaseModel):

--- a/frontend/src/hooks/useShareholders.ts
+++ b/frontend/src/hooks/useShareholders.ts
@@ -10,6 +10,10 @@ export interface Shareholder {
   actions: number;
   status: string;
   attendance_mode?: string | null;
+  representante?: string | null;
+  apoderado?: string | null;
+  attendee_id?: number | null;
+  apoderado_pdf?: boolean;
 }
 
 export const useShareholders = (


### PR DESCRIPTION
## Summary
- agregar datos de representante y apoderado para asistentes
- habilitar descarga de PDF de apoderados
- refactorizar UI de registro de asistencia con dropdown y acciones masivas

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a759b40594832280ed773fce05977e