### PR TITLE
feat: dynamic home page with role-based navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,8 @@ import EditElection from './pages/EditElection';
 import CreateElectionWizard from './pages/CreateElectionWizard';
 import Observer from './pages/Observer';
 import Ballots from './pages/Ballots';
+import Home from './pages/Home';
+import Configuracion from './pages/Configuracion';
 import { ToastProvider } from './components/ui/toast';
 
 const queryClient = new QueryClient();
@@ -32,44 +34,37 @@ const App: React.FC = () => {
       <ToastProvider>
         <AuthProvider>
           <Router>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-              <Route path="/register" element={<Register />} />
-              <Route path="/verify" element={<Verify />} />
-              <Route path="/reset-password" element={<RequestReset />} />
-              <Route path="/reset-password/:token" element={<ResetPassword />} />
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}> 
-                <Route element={<Layout />}> 
-                  <Route path="/votaciones" element={<Votaciones />} /> 
-                </Route> 
-              </Route>
-              <Route element={<ProtectedRoute roles={["FUNCIONAL_BVG", "ADMIN_BVG"]} />}>
-                <Route element={<Layout />}>
-                  <Route path="/votaciones/:id/attendance" element={<Asistencia />} />
+              <Routes>
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
+                <Route path="/verify" element={<Verify />} />
+                <Route path="/reset-password" element={<RequestReset />} />
+                <Route path="/reset-password/:token" element={<ResetPassword />} />
+                <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}> 
+                  <Route element={<Layout />}>
+                    <Route path="/" element={<Home />} />
+                    <Route path="/votaciones" element={<Votaciones />} />
+                    <Route path="/votaciones/:id/attendance" element={<Asistencia />} />
+                    <Route path="/votaciones/:id/dashboard" element={<Dashboard />} />
+                    <Route path="/votaciones/:id/observer" element={<Observer />} />
+                    <Route path="/votaciones/:id/ballots" element={<Ballots />} />
+                  </Route>
                 </Route>
-              </Route>
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}> 
-                <Route element={<Layout />}>
-                  <Route path="/votaciones/create" element={<CreateElectionWizard />} />
-                  <Route path="/votaciones/:id/upload" element={<UploadShareholders />} />
-                  <Route path="/votaciones/:id/proxies" element={<Proxies />} />
-                  <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} />
-                  <Route path="/votaciones/:id/audit" element={<AuditLogs />} />
-                  <Route path="/users" element={<ManageUsers />} />
-                  <Route path="/votaciones/:id/users" element={<ManageElectionUsers />} />
-                  <Route path="/votaciones/:id/edit" element={<EditElection />} />
+                <Route element={<ProtectedRoute roles={["ADMIN_BVG"]} />}> 
+                  <Route element={<Layout />}>
+                    <Route path="/votaciones/create" element={<CreateElectionWizard />} />
+                    <Route path="/votaciones/:id/upload" element={<UploadShareholders />} />
+                    <Route path="/votaciones/:id/proxies" element={<Proxies />} />
+                    <Route path="/votaciones/:id/assistants" element={<ManageAssistants />} />
+                    <Route path="/votaciones/:id/audit" element={<AuditLogs />} />
+                    <Route path="/users" element={<ManageUsers />} />
+                    <Route path="/votaciones/:id/users" element={<ManageElectionUsers />} />
+                    <Route path="/votaciones/:id/edit" element={<EditElection />} />
+                    <Route path="/config" element={<Configuracion />} />
+                  </Route>
                 </Route>
-              </Route>
-              <Route element={<ProtectedRoute roles={["ADMIN_BVG", "FUNCIONAL_BVG"]} />}> 
-                <Route element={<Layout />}> 
-                  <Route path="/votaciones/:id/dashboard" element={<Dashboard />} /> 
-                  <Route path="/votaciones/:id/observer" element={<Observer />} />
-                  <Route path="/votaciones/:id/ballots" element={<Ballots />} />
-                </Route> 
-              </Route>
-              <Route path="/" element={<Navigate to="/login" replace />} />
-              <Route path="*" element={<Navigate to="/" replace />} />
-            </Routes>
+                <Route path="*" element={<Navigate to="/" replace />} />
+              </Routes>
           </Router>
         </AuthProvider>
       </ToastProvider>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,30 +1,21 @@
 import React from 'react';
-import { NavLink, Outlet, useNavigate, useParams } from 'react-router-dom';
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { LogOut } from '../lib/icons';
 
 const Layout: React.FC = () => {
   const { role, username, logout } = useAuth();
   const navigate = useNavigate();
-  const { id } = useParams();
-  const base = id ? `/votaciones/${id}` : '';
 
   let links: { to: string; label: string }[] = [];
-  if (role === 'FUNCIONAL_BVG') {
-    if (base) {
-      links = [{ to: `${base}/attendance`, label: 'Registro' }];
-    }
-  } else if (role === 'ADMIN_BVG') {
+  if (role === 'ADMIN_BVG') {
+    links = [
+      { to: '/votaciones', label: 'Votaciones' },
+      { to: '/users', label: 'Usuarios' },
+      { to: '/config', label: 'Configuración' },
+    ];
+  } else if (role === 'FUNCIONAL_BVG') {
     links = [{ to: '/votaciones', label: 'Votaciones' }];
-    if (base) {
-      links.push(
-        { to: `${base}/upload`, label: 'Carga de padrón' },
-        { to: `${base}/attendance`, label: 'Registro de asistencia' },
-        { to: `${base}/proxies`, label: 'Apoderados' },
-        { to: `${base}/dashboard`, label: 'Dashboard' },
-      );
-    }
-    links.push({ to: '/users', label: 'Usuarios' });
   }
 
   const handleLogout = () => {
@@ -33,13 +24,10 @@ const Layout: React.FC = () => {
   };
 
   return (
-    <div className="app-gradient min-vh-100 d-flex flex-column">
-      <div className="floating-shape shape-1" />
-      <div className="floating-shape shape-2" />
-      <div className="floating-shape shape-3" />
-      <nav className="navbar navbar-expand-md bvg-navbar fixed-top">
+    <div className="min-vh-100 d-flex flex-column">
+      <nav className="navbar navbar-expand-md bg-white border-bottom fixed-top">
         <div className="container-fluid">
-          <NavLink to="/votaciones" className="navbar-brand fw-bold text-white">
+          <NavLink to="/" className="navbar-brand fw-bold">
             BVG
           </NavLink>
           <button
@@ -67,7 +55,7 @@ const Layout: React.FC = () => {
               ))}
               {username && role && (
                 <li className="nav-item d-none d-md-block">
-                  <span className="nav-link disabled text-white-50 small">
+                  <span className="nav-link disabled text-body-secondary small">
                     {role} - {username}
                   </span>
                 </li>
@@ -87,7 +75,7 @@ const Layout: React.FC = () => {
       <main className="container py-4 mt-5 flex-grow-1">
         <Outlet />
       </main>
-      <footer className="bvg-footer text-center py-3 mt-auto">
+      <footer className="text-center py-3 border-top mt-auto bg-white">
         <small>&copy; BVG</small>
       </footer>
     </div>

--- a/frontend/src/pages/Configuracion.tsx
+++ b/frontend/src/pages/Configuracion.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Configuracion: React.FC = () => (
+  <div className="container py-4">
+    <h1 className="h4 mb-4">Configuración</h1>
+    <p className="text-body-secondary">
+      Personalización del sistema (logos, colores corporativos, parámetros generales).
+    </p>
+  </div>
+);
+
+export default Configuracion;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+interface Section {
+  to: string;
+  title: string;
+  description: string;
+}
+
+const Home: React.FC = () => {
+  const { role } = useAuth();
+
+  const sections: Section[] = [];
+
+  if (role === 'ADMIN_BVG') {
+    sections.push(
+      {
+        to: '/votaciones',
+        title: 'Votaciones',
+        description: 'Crear y gestionar procesos de votación.',
+      },
+      {
+        to: '/users',
+        title: 'Usuarios',
+        description: 'Administración de usuarios y roles.',
+      },
+      {
+        to: '/config',
+        title: 'Configuración',
+        description: 'Personalización del sistema.',
+      }
+    );
+  } else if (role === 'FUNCIONAL_BVG') {
+    sections.push({
+      to: '/votaciones',
+      title: 'Votaciones',
+      description: 'Acceso a los procesos según sus permisos.',
+    });
+  }
+
+  return (
+    <div className="container py-4">
+      <h1 className="h4 mb-4">Inicio</h1>
+      <div className="row g-3">
+        {sections.map((s) => (
+          <div key={s.to} className="col-md-4">
+            <div className="border rounded p-4 h-100 bg-white">
+              <h2 className="h5 mb-2">{s.title}</h2>
+              <p className="mb-3 text-body-secondary">{s.description}</p>
+              <Link to={s.to} className="btn btn-primary">
+                Ingresar
+              </Link>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Home;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -22,7 +22,7 @@ const Login: React.FC = () => {
     },
     onSuccess: (data) => {
       login(data.access_token, data.role, data.username);
-      navigate('/votaciones');
+      navigate('/');
     },
     onError: (err: any) => {
       setError(err.message);


### PR DESCRIPTION
## Summary
- add dynamic home page with neutral card layout that adjusts to user role
- simplify layout with clean navbar and role-aware links
- expose configuration section and redirect login to home

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a78e97861c832297e8fa63156ac8d1