### PR TITLE
Allow vote registrars to see attendance summary

### DIFF
--- a/backend/app/routers/attendance.py
+++ b/backend/app/routers/attendance.py
@@ -252,7 +252,15 @@ def attendance_history(election_id: int, code: str, db: Session = Depends(get_db
 
 @router.get(
     "/summary",
-    dependencies=[require_election_role([models.ElectionRole.ATTENDANCE])]
+    dependencies=[
+        require_election_role(
+            [
+                models.ElectionRole.ATTENDANCE,
+                models.ElectionRole.VOTE,
+                models.ElectionRole.OBSERVER,
+            ]
+        )
+    ]
 )
 def summary_attendance(election_id: int, db: Session = Depends(get_db)):
     return compute_summary(db, election_id)

--- a/frontend/src/hooks/useBulkMarkAttendance.ts
+++ b/frontend/src/hooks/useBulkMarkAttendance.ts
@@ -32,6 +32,7 @@ export const useBulkMarkAttendance = (
         );
       });
       queryClient.invalidateQueries({ queryKey: ['shareholders', electionId] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard', electionId] });
       onSuccess?.(data);
     },
     onError: (err) => {

--- a/frontend/src/hooks/useMarkAttendance.ts
+++ b/frontend/src/hooks/useMarkAttendance.ts
@@ -29,6 +29,7 @@ export const useMarkAttendance = (
         );
       });
       queryClient.invalidateQueries({ queryKey: ['shareholders', electionId] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard', electionId] });
       onSuccess?.();
     },
     onError: (err) => {

--- a/frontend/src/lib/react-query.test.ts
+++ b/frontend/src/lib/react-query.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient } from './react-query';
+
+describe('QueryClient prefix matching', () => {
+  it('invalidates queries with matching prefix', () => {
+    const qc = new QueryClient();
+    const refetch = vi.fn();
+    qc.subscribe(['shareholders', 1, 'search'], { refetch, setData: vi.fn() });
+    qc.invalidateQueries({ queryKey: ['shareholders', 1] });
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('updates queries with matching prefix', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(['shareholders', 1, 'search'], 1);
+    qc.updateQueriesData(['shareholders', 1], (old) => (old || 0) + 1);
+    expect(qc.getQueryData(['shareholders', 1, 'search'])).toBe(2);
+  });
+});

--- a/frontend/src/lib/react-query.tsx
+++ b/frontend/src/lib/react-query.tsx
@@ -17,9 +17,10 @@ export class QueryClient {
   }
 
   invalidateQueries(opts: { queryKey: any[] }) {
-    const prefix = JSON.stringify(opts.queryKey);
+    const prefix = opts.queryKey;
     for (const [key, subs] of this.listeners.entries()) {
-      if (key.startsWith(prefix)) {
+      const parsed = JSON.parse(key);
+      if (prefix.every((v, i) => parsed[i] === v)) {
         subs.forEach((l) => l.refetch());
       }
     }
@@ -37,9 +38,10 @@ export class QueryClient {
   }
 
   updateQueriesData(prefixKey: any[], updater: (old: any) => any) {
-    const prefix = JSON.stringify(prefixKey);
+    const prefix = prefixKey;
     for (const [key, value] of this.cache.entries()) {
-      if (key.startsWith(prefix)) {
+      const parsed = JSON.parse(key);
+      if (prefix.every((v, i) => parsed[i] === v)) {
         const newData = updater(value);
         this.cache.set(key, newData);
         const subs = this.listeners.get(key);


### PR DESCRIPTION
## Summary
- Permit vote registrars and observers to fetch attendance summary
- Fix QueryClient prefix matching to properly invalidate nested keys
- Refresh dashboard stats when marking attendance individually or in bulk
- Add unit test for QueryClient prefix handling

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68abc7b865208322bcba13f9a1ba98b8