### PR TITLE
Fix attendee ordering and registration access, improve vote handling

### DIFF
--- a/backend/app/routers/assistants.py
+++ b/backend/app/routers/assistants.py
@@ -179,7 +179,12 @@ def import_attendees_excel(
     dependencies=[require_role(["FUNCIONAL_BVG", "ADMIN_BVG"])]
 )
 def list_attendees(election_id: int, db: Session = Depends(get_db)):
-    attendees = db.query(models.Attendee).filter_by(election_id=election_id).all()
+    attendees = (
+        db.query(models.Attendee)
+        .filter_by(election_id=election_id)
+        .order_by(models.Attendee.id)
+        .all()
+    )
     result: List[schemas.Attendee] = []
     for att in attendees:
         data = schemas.Attendee.model_validate(att).model_dump()

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -9,14 +9,9 @@ def enforce_registration_window(db: Session, election_id: int, user):
     if not election:
         raise HTTPException(status_code=404, detail="election not found")
     now = datetime.now(timezone.utc)
-    start = election.registration_start
     end = election.registration_end
-    if start and start.tzinfo is None:
-        start = start.replace(tzinfo=timezone.utc)
     if end and end.tzinfo is None:
         end = end.replace(tzinfo=timezone.utc)
-    if start and now < start and user["role"] != "ADMIN_BVG":
-        raise HTTPException(status_code=403, detail="registration not started")
     if end and now > end and user["role"] != "ADMIN_BVG":
         raise HTTPException(status_code=403, detail="registration closed")
     return election

--- a/frontend/src/hooks/useBallots.ts
+++ b/frontend/src/hooks/useBallots.ts
@@ -39,7 +39,11 @@ export const useBallotResults = (ballotId: number, enabled = true) => {
   });
 };
 
-export const useCastVote = (ballotId: number, onSuccess?: () => void) => {
+export const useCastVote = (
+  ballotId: number,
+  onSuccess?: () => void,
+  onError?: (err: any) => void,
+) => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: { option_id: number; attendee_id: number }) =>
@@ -52,10 +56,15 @@ export const useCastVote = (ballotId: number, onSuccess?: () => void) => {
       qc.invalidateQueries({ queryKey: ['ballot-results', ballotId] });
       onSuccess?.();
     },
+    onError,
   });
 };
 
-export const useVoteAll = (ballotId: number, onSuccess?: () => void) => {
+export const useVoteAll = (
+  ballotId: number,
+  onSuccess?: () => void,
+  onError?: (err: any) => void,
+) => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: { option_id: number }) =>
@@ -68,6 +77,7 @@ export const useVoteAll = (ballotId: number, onSuccess?: () => void) => {
       qc.invalidateQueries({ queryKey: ['ballot-results', ballotId] });
       onSuccess?.();
     },
+    onError,
   });
 };
 

--- a/frontend/src/pages/Votaciones.test.tsx
+++ b/frontend/src/pages/Votaciones.test.tsx
@@ -65,6 +65,25 @@ describe('Votaciones', () => {
     expect(btn.getAttribute('title')).toBe('Registro de asistencia no habilitado');
   });
 
+  it('habilita gestionar antes del inicio del registro', async () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    mockRole = 'FUNCIONAL_BVG';
+    vi.spyOn(api, 'apiFetch').mockResolvedValue([
+      {
+        id: 5,
+        name: 'Elec5',
+        date: '2024-01-01',
+        status: 'OPEN',
+        registration_start: future,
+        registration_end: new Date(Date.now() + 172800000).toISOString(),
+        can_manage_attendance: true,
+      },
+    ]);
+    renderPage();
+    const btn = await screen.findByRole('button', { name: /Gestionar asistentes/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it('oculta observador cuando no tiene permiso', async () => {
     mockRole = 'FUNCIONAL_BVG';
     vi.spyOn(api, 'apiFetch').mockResolvedValue([

--- a/frontend/src/pages/Votaciones.tsx
+++ b/frontend/src/pages/Votaciones.tsx
@@ -42,7 +42,6 @@ const Votaciones: React.FC = () => {
   const isRegistrationOpen = (e: any) => {
     if (e.status !== 'OPEN') return false;
     const now = new Date();
-    if (e.registration_start && new Date(e.registration_start) > now) return false;
     if (e.registration_end && new Date(e.registration_end) < now) return false;
     return true;
   };

--- a/frontend/src/pages/Vote.test.tsx
+++ b/frontend/src/pages/Vote.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '../lib/react-query';
+import { ToastProvider } from '../components/ui/toast';
+import Vote from './Vote';
+
+const toastMock = vi.fn();
+vi.mock('../components/ui/toast', () => ({
+  useToast: () => toastMock,
+  ToastProvider: ({ children }: any) => <div>{children}</div>,
+}));
+
+let mockSuccess = true;
+
+vi.mock('../hooks/useElection', () => ({
+  useElection: () => ({ data: { status: 'OPEN', min_quorum: 0, voting_open: true } }),
+}));
+vi.mock('../hooks/useDashboardStats', () => ({
+  useDashboardStats: () => ({ data: { porcentaje_quorum: 100 } }),
+}));
+vi.mock('../hooks/useBallots', () => ({
+  usePendingBallots: () => ({ data: [{ id: 1, title: 'Q1' }] }),
+  useBallotResults: () => ({ data: [{ id: 10, text: 'Sí' }] }),
+  useCastVote: (_id: number, onSuccess?: () => void, onError?: (err: any) => void) => ({
+    mutate: (_: any) => {
+      mockSuccess ? onSuccess?.() : onError?.(new Error('fail'));
+    },
+  }),
+  useVoteAll: (_id: number, onSuccess?: () => void, onError?: (err: any) => void) => ({
+    mutate: (_: any) => {
+      mockSuccess ? onSuccess?.() : onError?.(new Error('fail'));
+    },
+  }),
+  useCloseBallot: () => ({ mutate: vi.fn() }),
+  useCloseElection: () => ({ mutate: vi.fn() }),
+  useStartVoting: () => ({ mutate: vi.fn() }),
+  useCloseVoting: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('../hooks/useShareholders', () => ({
+  useShareholders: () => ({
+    data: [{ attendee_id: 5, name: 'Alice', attendance_mode: 'PRESENCIAL' }],
+  }),
+}));
+
+const renderPage = () => {
+  const client = new QueryClient();
+  return render(
+    <MemoryRouter initialEntries={["/votaciones/1/vote"]}>
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <Routes>
+            <Route path="/votaciones/:id/vote" element={<Vote />} />
+          </Routes>
+        </ToastProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+};
+
+describe('Vote page', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('muestra error cuando el voto individual falla', async () => {
+    mockSuccess = false;
+    renderPage();
+    const radio = await screen.findByRole('radio');
+    fireEvent.click(radio);
+    expect(toastMock).toHaveBeenCalledWith('fail');
+  });
+
+  it('registra voto individual exitoso', async () => {
+    mockSuccess = true;
+    renderPage();
+    const radio = await screen.findByRole('radio');
+    fireEvent.click(radio);
+    expect(toastMock).toHaveBeenCalledWith('Voto registrado');
+  });
+});
+

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -10,7 +10,7 @@ import {
   useStartVoting,
   useCloseVoting,
 } from '../hooks/useBallots';
-import { useAssistants } from '../hooks/useAssistants';
+import { useShareholders } from '../hooks/useShareholders';
 import { useElection } from '../hooks/useElection';
 import { useDashboardStats } from '../hooks/useDashboardStats';
 import Button from '../components/ui/button';
@@ -22,7 +22,17 @@ const Vote: React.FC = () => {
   const electionId = Number(id);
   const { data: election } = useElection(electionId);
   const { data: ballots } = usePendingBallots(electionId);
-  const { data: assistants } = useAssistants(electionId);
+  const { data: shareholders } = useShareholders(
+    electionId,
+    '',
+    (err) => toast(err.message),
+  );
+  const assistants =
+    shareholders
+      ?.filter(
+        (s) => s.attendee_id && s.attendance_mode && s.attendance_mode !== 'AUSENTE',
+      )
+      .map((s) => ({ id: s.attendee_id!, accionista: s.name })) || [];
   const { data: stats } = useDashboardStats(electionId);
   const [index, setIndex] = useState(0);
   const current = ballots?.[index];
@@ -34,8 +44,16 @@ const Vote: React.FC = () => {
     setVotes({});
   }, [current?.id]);
 
-  const castVote = useCastVote(current?.id || 0, () => toast('Voto registrado'));
-  const voteAll = useVoteAll(current?.id || 0, () => toast('Votos registrados'));
+  const castVote = useCastVote(
+    current?.id || 0,
+    () => toast('Voto registrado'),
+    (err) => toast(err.message),
+  );
+  const voteAll = useVoteAll(
+    current?.id || 0,
+    () => toast('Votos registrados'),
+    (err) => toast(err.message),
+  );
   const closeBallot = useCloseBallot(current?.id || 0, () => setIndex((i) => i + 1));
   const closeElection = useCloseElection(electionId, () => toast('Votación cerrada'));
   const startVoting = useStartVoting(electionId);
@@ -48,7 +66,7 @@ const Vote: React.FC = () => {
 
   const handleVoteAll = (optionId: number) => {
     const map: Record<number, number> = {};
-    assistants?.forEach((a) => {
+    assistants.forEach((a) => {
       map[a.id] = optionId;
     });
     setVotes(map);


### PR DESCRIPTION
## Summary
- keep attendee listing order stable
- ignore registration start when allowing attendance updates and add tests
- show vote errors and only list present attendees when casting votes

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68abcdf9f55c832290984bc1f040550a