### PR TITLE
Fix ballot sync and question IDs

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from typing import Optional, List
-from pydantic import BaseModel, EmailStr, ConfigDict
+from pydantic import BaseModel, EmailStr, ConfigDict, Field
 from .models import (
     AttendanceMode,
     PersonType,
@@ -150,7 +150,7 @@ class Proxy(BaseModel):
     present: bool = False
     marked_by: Optional[str] = None
     marked_at: Optional[datetime] = None
-    assignments: List[ProxyAssignment] = []
+    assignments: List[ProxyAssignment] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -182,7 +182,7 @@ class QuestionCreate(BaseModel):
     type: QuestionType
     required: bool = False
     order: int
-    options: List[QuestionOption] = []
+    options: List[QuestionOption] = Field(default_factory=list)
 
 
 class Question(QuestionCreate):
@@ -203,10 +203,10 @@ class ElectionBase(BaseModel):
 
 class ElectionCreate(ElectionBase):
     status: ElectionStatus = ElectionStatus.DRAFT
-    attendance_registrars: List[int] = []
-    vote_registrars: List[int] = []
-    observers: List[int] = []
-    questions: List["QuestionCreate"] = []
+    attendance_registrars: List[int] = Field(default_factory=list)
+    vote_registrars: List[int] = Field(default_factory=list)
+    observers: List[int] = Field(default_factory=list)
+    questions: List["QuestionCreate"] = Field(default_factory=list)
 
 
 class ElectionUpdate(BaseModel):

--- a/frontend/src/pages/EditElection.tsx
+++ b/frontend/src/pages/EditElection.tsx
@@ -29,6 +29,7 @@ const EditElection: React.FC = () => {
         qs.map((q) => {
           const opts = q.options?.map((o: any) => o.text) || [];
           return {
+            id: String(q.id),
             text: q.text,
             type: q.type,
             required: q.required,

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   useBallots,
@@ -40,21 +40,25 @@ const Vote: React.FC = () => {
       .map((s) => ({ id: s.attendee_id!, accionista: s.name })) || [];
   const { data: stats } = useDashboardStats(electionId);
   const [index, setIndex] = useState(0);
+  const currentIdRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (allBallots) {
-      const currentId = ballots[index]?.id;
-      setBallots(allBallots);
-      if (ballots.length === 0) {
-        advance(0, allBallots);
-      } else if (currentId) {
-        const idx = allBallots.findIndex((b) => b.id === currentId);
-        if (idx !== -1) {
-          advance(idx, allBallots);
-        }
+    currentIdRef.current = ballots[index]?.id ?? null;
+  }, [ballots, index]);
+
+  useEffect(() => {
+    if (!allBallots) return;
+    setBallots(allBallots);
+    if (allBallots.length === 0) {
+      advance(0, allBallots);
+    } else if (currentIdRef.current) {
+      const idx = allBallots.findIndex((b) => b.id === currentIdRef.current);
+      if (idx !== -1) {
+        advance(idx, allBallots);
       }
+    } else {
+      advance(0, allBallots);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allBallots]);
 
   const advance = (i: number, list: Ballot[] = ballots) => {


### PR DESCRIPTION
## Summary
- Track current ballot with a ref to keep question index in sync when ballots refresh
- Prevent shared mutable lists in Pydantic schemas by using `Field(default_factory=list)`
- Assign unique IDs to questions in the builder and update editor to use them

## Testing
- `pytest`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68ace01d53c88322bed89df8b0e60733