### PR TITLE
Pass electionId to ballot mutation hooks

### DIFF
--- a/frontend/src/hooks/useBallots.ts
+++ b/frontend/src/hooks/useBallots.ts
@@ -82,27 +82,35 @@ export const useVoteAll = (
   });
 };
 
-export const useCloseBallot = (ballotId: number, onSuccess?: () => void) => {
+export const useCloseBallot = (
+  ballotId: number,
+  electionId: number,
+  onSuccess?: () => void,
+) => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () =>
       apiFetch(`/ballots/${ballotId}/close`, { method: 'POST' }),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['ballots'] });
-      qc.invalidateQueries({ queryKey: ['pending-ballots'] });
+      qc.invalidateQueries({ queryKey: ['ballots', electionId] });
+      qc.invalidateQueries({ queryKey: ['pending-ballots', electionId] });
       onSuccess?.();
     },
   });
 };
 
-export const useReopenBallot = (ballotId: number, onSuccess?: () => void) => {
+export const useReopenBallot = (
+  ballotId: number,
+  electionId: number,
+  onSuccess?: () => void,
+) => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () =>
       apiFetch(`/ballots/${ballotId}/reopen`, { method: 'POST' }),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['ballots'] });
-      qc.invalidateQueries({ queryKey: ['pending-ballots'] });
+      qc.invalidateQueries({ queryKey: ['ballots', electionId] });
+      qc.invalidateQueries({ queryKey: ['pending-ballots', electionId] });
       onSuccess?.();
     },
   });

--- a/frontend/src/pages/Ballots.tsx
+++ b/frontend/src/pages/Ballots.tsx
@@ -30,7 +30,11 @@ const Ballots: React.FC = () => {
   const attendeeId = attendee?.id;
   const toast = useToast();
   const castVote = useCastVote(selected || 0, () => toast('Voto registrado'));
-  const reopenBallot = useReopenBallot(selected || 0, () => toast('Boleta reabierta'));
+  const reopenBallot = useReopenBallot(
+    selected || 0,
+    electionId,
+    () => toast('Boleta reabierta'),
+  );
 
   return (
     <div className="space-y-4">

--- a/frontend/src/pages/Vote.test.tsx
+++ b/frontend/src/pages/Vote.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../hooks/useBallots', () => ({
       mockSuccess ? onSuccess?.() : onError?.(new Error('fail'));
     },
   }),
-  useCloseBallot: (_id: number, onSuccess?: () => void) => ({
+  useCloseBallot: (_id: number, _eId: number, onSuccess?: () => void) => ({
     mutate: () => onSuccess?.(),
   }),
   useCloseElection: () => ({ mutate: vi.fn() }),

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -89,7 +89,7 @@ const Vote: React.FC = () => {
     () => toast('Votos registrados'),
     (err) => toast(err.message),
   );
-  const closeBallot = useCloseBallot(current?.id || 0, () => {
+  const closeBallot = useCloseBallot(current?.id || 0, electionId, () => {
     if (current) {
       setBallots((prev) => {
         const updated = prev.map((b) =>


### PR DESCRIPTION
## Summary
- Accept electionId in `useCloseBallot` and `useReopenBallot`
- Invalidate election-specific ballot queries after closing or reopening
- Update vote and ballots pages and tests to pass electionId

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_68adc43101608322a8dfd01fe8fa3c5e