### PR TITLE
Improve ballot navigation speed in voting page

### DIFF
--- a/frontend/src/components/QuestionWizard.tsx
+++ b/frontend/src/components/QuestionWizard.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Button from './ui/button';
+import type { Ballot } from '../hooks/useBallots';
+
+interface QuestionWizardProps {
+  ballots: Ballot[];
+  currentStep: number;
+  onNext: () => void;
+  onPrev: () => void;
+  children: React.ReactNode;
+}
+
+const QuestionWizard: React.FC<QuestionWizardProps> = ({
+  ballots,
+  currentStep,
+  onNext,
+  onPrev,
+  children,
+}) => {
+  const total = ballots.length;
+  const progress = Math.min(currentStep + 1, total);
+  const percentage = total ? (progress / total) * 100 : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="outline" disabled={currentStep === 0} onClick={onPrev}>
+          Anterior
+        </Button>
+        <div className="flex-1">
+          <div>
+            Pregunta {progress} de {total}
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2 mt-1">
+            <div
+              className="bg-blue-500 h-2 rounded-full"
+              style={{ width: `${percentage}%` }}
+            ></div>
+          </div>
+        </div>
+        <Button variant="outline" disabled={total === 0} onClick={onNext}>
+          Siguiente pregunta
+        </Button>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default QuestionWizard;
+


### PR DESCRIPTION
## Summary
- Keep local ballot list instead of replacing with refreshed data
- Navigate questions immediately with new QuestionWizard component
- Skip ballots without options while closing them in background

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68add23d72fc8322a718e8362a3a6d12