### PR TITLE
Improve ballot navigation speed in voting page

### DIFF
--- a/frontend/src/components/QuestionWizard.tsx
+++ b/frontend/src/components/QuestionWizard.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Button from './ui/button';
+import type { Ballot } from '../hooks/useBallots';
+
+interface QuestionWizardProps {
+  ballots: Ballot[];
+  currentStep: number;
+  onNext: () => void;
+  onPrev: () => void;
+  children: React.ReactNode;
+}
+
+const QuestionWizard: React.FC<QuestionWizardProps> = ({
+  ballots,
+  currentStep,
+  onNext,
+  onPrev,
+  children,
+}) => {
+  const total = ballots.length;
+  const progress = Math.min(currentStep + 1, total);
+  const percentage = total ? (progress / total) * 100 : 0;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm text-gray-600">
+          Pregunta {progress} de {total}
+        </p>
+        <div className="w-full bg-gray-200 rounded-full h-2 mt-1">
+          <div
+            className="bg-blue-500 h-2 rounded-full"
+            style={{ width: `${percentage}%` }}
+          ></div>
+        </div>
+      </div>
+      {children}
+      <div className="flex justify-between">
+        <Button variant="outline" disabled={currentStep === 0} onClick={onPrev}>
+          Anterior
+        </Button>
+        <Button disabled={total === 0} onClick={onNext}>
+          Siguiente
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionWizard;
+

--- a/frontend/src/pages/Vote.test.tsx
+++ b/frontend/src/pages/Vote.test.tsx
@@ -144,7 +144,7 @@ describe('Vote page', () => {
     renderPage();
     const radio = await screen.findByRole('radio');
     fireEvent.click(radio);
-    const btn = screen.getByRole('button', { name: 'Siguiente pregunta' });
+    const btn = screen.getByRole('button', { name: 'Siguiente' });
     fireEvent.click(btn);
     await screen.findByText('Q2');
   });
@@ -175,7 +175,7 @@ describe('Vote page', () => {
       seen.push(title);
       const radio = screen.getByRole('radio');
       fireEvent.click(radio);
-      const btn = screen.getByRole('button', { name: 'Siguiente pregunta' });
+      const btn = screen.getByRole('button', { name: 'Siguiente' });
       fireEvent.click(btn);
     }
     expect(new Set(seen).size).toBe(seen.length);


### PR DESCRIPTION
## Summary
- Keep local ballot list instead of replacing with refreshed data
- Navigate questions immediately with new QuestionWizard component
- Skip ballots without options while closing them in background
- Style wizard with top progress bar and bottom navigation

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68add23d72fc8322a718e8362a3a6d12