### PR TITLE
Filtrar asistentes votantes y remount de preguntas

### DIFF
--- a/frontend/src/pages/Vote.test.tsx
+++ b/frontend/src/pages/Vote.test.tsx
@@ -57,7 +57,14 @@ vi.mock('../hooks/useBallots', () => ({
 }));
 vi.mock('../hooks/useShareholders', () => ({
   useShareholders: () => ({
-    data: [{ attendee_id: 5, name: 'Alice', attendance_mode: 'PRESENCIAL' }],
+    data: [
+      {
+        attendee_id: 5,
+        name: 'Alice',
+        attendance_mode: 'PRESENCIAL',
+        actions: 1,
+      },
+    ],
   }),
 }));
 

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -36,7 +36,11 @@ const Vote: React.FC = () => {
   const assistants =
     shareholders
       ?.filter(
-        (s) => s.attendee_id && s.attendance_mode && s.attendance_mode !== 'AUSENTE',
+        (s) =>
+          s.attendee_id &&
+          s.attendance_mode &&
+          s.attendance_mode !== 'AUSENTE' &&
+          s.actions > 0,
       )
       .map((s) => ({ id: s.attendee_id!, accionista: s.name })) || [];
   const { data: stats } = useDashboardStats(electionId);
@@ -195,6 +199,7 @@ const Vote: React.FC = () => {
           <p>Cargando opciones...</p>
         ) : options && options.length > 0 ? (
           <QuestionWizard
+            key={current.id}
             ballots={ballots}
             currentStep={currentStep}
             onNext={nextQuestion}


### PR DESCRIPTION
## Summary
- Filtra asistentes en la votación dejando solo accionistas con acciones presentes o virtuales
- Fuerza el re-render del componente `QuestionWizard` al cambiar de pregunta
- Ajusta pruebas para reflejar nueva lógica de asistentes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ae109a8690832280adce80b7ec1c55