### PR TITLE
Adjust vote reporting to present capital and require votes for navigation

### DIFF
--- a/backend/app/templates/vote_report.html
+++ b/backend/app/templates/vote_report.html
@@ -18,9 +18,10 @@
   <h1>Informe de votación - {{ election.name }}</h1>
   <section class="summary">
     <h2>Resumen</h2>
-    <p>Acciones presentes:
+    <p>
+      Acciones presentes:
       {{ summary.capital_presente_directo + summary.capital_presente_representado }}
-      ({{ (summary.porcentaje_quorum*100)|round(2) }}%)
+      (100%) — {{ (summary.porcentaje_quorum*100)|round(2) }}% sobre capital suscrito
     </p>
   </section>
   <section class="attendees">

--- a/frontend/src/components/QuestionWizard.tsx
+++ b/frontend/src/components/QuestionWizard.tsx
@@ -8,6 +8,7 @@ interface QuestionWizardProps {
   onNext: () => void;
   onPrev: () => void;
   children: React.ReactNode;
+  nextDisabled?: boolean;
 }
 
 const QuestionWizard: React.FC<QuestionWizardProps> = ({
@@ -16,6 +17,7 @@ const QuestionWizard: React.FC<QuestionWizardProps> = ({
   onNext,
   onPrev,
   children,
+  nextDisabled,
 }) => {
   const total = ballots.length;
   const progress = Math.min(currentStep + 1, total);
@@ -39,7 +41,7 @@ const QuestionWizard: React.FC<QuestionWizardProps> = ({
         <Button variant="outline" disabled={currentStep === 0} onClick={onPrev}>
           Anterior
         </Button>
-        <Button disabled={total === 0} onClick={onNext}>
+        <Button disabled={total === 0 || nextDisabled} onClick={onNext}>
           Siguiente
         </Button>
       </div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -16,10 +16,14 @@ const Dashboard: React.FC = () => {
       </p>
     );
 
+  const totalPresentes = data.presencial + data.virtual;
+  const pctPresencial = totalPresentes
+    ? (data.presencial / totalPresentes) * 100
+    : 0;
+  const pctVirtual = totalPresentes ? (data.virtual / totalPresentes) * 100 : 0;
   const pieData = [
-    { name: 'Presencial', value: data.presencial, color: 'var(--bvg-blue)' },
-    { name: 'Virtual', value: data.virtual, color: 'var(--bvg-blue-light)' },
-    { name: 'Ausente', value: data.ausente, color: 'var(--bvg-gray)' },
+    { name: 'Presencial', value: pctPresencial, color: 'var(--bvg-blue)' },
+    { name: 'Virtual', value: pctVirtual, color: 'var(--bvg-blue-light)' },
   ];
 
   const barData = [
@@ -34,7 +38,7 @@ const Dashboard: React.FC = () => {
         <div role="img" aria-label="Distribución de asistencia">
           <PieChart width={300} height={200} data={pieData} />
           <p className="visually-hidden">
-            Presencial {data.presencial}, Virtual {data.virtual}, Ausente {data.ausente}
+            Presencial {pctPresencial.toFixed(2)}%, Virtual {pctVirtual.toFixed(2)}%
           </p>
         </div>
         <div role="img" aria-label="Capital presente directo versus representado">

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -74,6 +74,7 @@ const Vote: React.FC = () => {
   const [votes, setVotes] = useState<Record<number, number>>({});
   const [alertMsg, setAlertMsg] = useState('');
   const toast = useToast();
+  const allVoted = assistants.every((a) => votes[a.id]);
 
   useEffect(() => {
     setVotes({});
@@ -204,6 +205,7 @@ const Vote: React.FC = () => {
             currentStep={currentStep}
             onNext={nextQuestion}
             onPrev={prevQuestion}
+            nextDisabled={!allVoted}
           >
             {alertMsg && <Alert message={alertMsg} />}
             <h2 className="text-lg font-medium">{current.title}</h2>


### PR DESCRIPTION
## Summary
- Compute vote percentages over the total capital present and clarify this in vote reports
- Prevent moving to the next ballot until every attendee has voted
- Show attendance percentages based only on present and virtual participants

## Testing
- `pytest -q`
- `npm test --prefix frontend -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68ae1ed0703483229b828cd5e578c3a6