### PR TITLE
Filter vote-all by attendance

### DIFF
--- a/backend/app/routers/voting.py
+++ b/backend/app/routers/voting.py
@@ -650,7 +650,24 @@ def vote_all(
         raise HTTPException(status_code=400, detail="Invalid option for ballot")
     attendees = (
         db.query(models.Attendee)
-        .filter_by(election_id=ballot.election_id)
+        .join(
+            models.Shareholder,
+            models.Attendee.identifier == models.Shareholder.code,
+        )
+        .join(
+            models.Attendance,
+            (
+                models.Attendance.shareholder_id == models.Shareholder.id
+            )
+            & (
+                models.Attendance.election_id == models.Attendee.election_id
+            ),
+        )
+        .filter(
+            models.Attendance.present.is_(True),
+            models.Attendee.acciones > 0,
+            models.Attendee.election_id == ballot.election_id,
+        )
         .all()
     )
     count = 0

--- a/backend/tests/test_observer.py
+++ b/backend/tests/test_observer.py
@@ -140,6 +140,18 @@ def test_observer_table_shows_represented_actions():
 def test_observer_receives_ballot_progress():
     election_id, admin_headers, reg_headers, obs_headers, obs_token, _, _ = setup_env()
     db = SessionLocal()
+    sh = models.Shareholder(code="1", name="A1", document="D1", actions=10)
+    db.add(sh)
+    db.commit()
+    db.refresh(sh)
+    db.add(
+        models.Attendance(
+            election_id=election_id,
+            shareholder_id=sh.id,
+            mode=models.AttendanceMode.PRESENCIAL,
+            present=True,
+        )
+    )
     db.add(
         models.Attendee(
             election_id=election_id, identifier="1", accionista="A1", acciones=10


### PR DESCRIPTION
## Summary
- Count only present shareholders with positive shares when casting votes via /vote-all
- Add regression test ensuring absent attendees are skipped
- Update observer and voting tests to mark attendees present for vote-all

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae299ec3a08322927f30e3a2e952ab