### PR TITLE
fix: update ballot pointer without race conditions

### DIFF
--- a/frontend/src/components/BallotStepper.tsx
+++ b/frontend/src/components/BallotStepper.tsx
@@ -2,25 +2,26 @@ import React from 'react';
 import Button from './ui/button';
 import type { Ballot } from '../hooks/useBallots';
 
-interface QuestionWizardProps {
+interface BallotStepperProps {
   ballots: Ballot[];
-  currentStep: number;
+  currentBallotId: number | null;
   onNext: () => void;
   onPrev: () => void;
   children: React.ReactNode;
   nextDisabled?: boolean;
 }
 
-const QuestionWizard: React.FC<QuestionWizardProps> = ({
+const BallotStepper: React.FC<BallotStepperProps> = ({
   ballots,
-  currentStep,
+  currentBallotId,
   onNext,
   onPrev,
   children,
   nextDisabled,
 }) => {
+  const index = ballots.findIndex((b) => b.id === currentBallotId);
+  const progress = index >= 0 ? index + 1 : ballots.length;
   const total = ballots.length;
-  const progress = Math.min(currentStep + 1, total);
   const percentage = total ? (progress / total) * 100 : 0;
 
   return (
@@ -38,7 +39,7 @@ const QuestionWizard: React.FC<QuestionWizardProps> = ({
       </div>
       {children}
       <div className="flex justify-between">
-        <Button variant="outline" disabled={currentStep === 0} onClick={onPrev}>
+        <Button variant="outline" disabled={index <= 0} onClick={onPrev}>
           Anterior
         </Button>
         <Button disabled={total === 0 || nextDisabled} onClick={onNext}>
@@ -49,4 +50,4 @@ const QuestionWizard: React.FC<QuestionWizardProps> = ({
   );
 };
 
-export default QuestionWizard;
+export default BallotStepper;

--- a/frontend/src/hooks/useBallots.ts
+++ b/frontend/src/hooks/useBallots.ts
@@ -92,7 +92,11 @@ export const useCloseBallot = (
     mutationFn: () =>
       apiFetch(`/ballots/${ballotId}/close`, { method: 'POST' }),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['ballots', electionId] });
+      qc.setQueryData<Ballot[]>(['ballots', electionId], (prev) =>
+        prev?.map((b) =>
+          b.id === ballotId ? { ...b, status: 'CLOSED' } : b,
+        ),
+      );
       qc.invalidateQueries({ queryKey: ['pending-ballots', electionId] });
       onSuccess?.();
     },

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -20,7 +20,7 @@ import { useToast } from '../components/ui/toast';
 import Alert from '../components/ui/alert';
 import { useVoteReport } from '../hooks/useVoteReport';
 import { useSendVoteReport } from '../hooks/useSendVoteReport';
-import QuestionWizard from '../components/QuestionWizard';
+import BallotStepper from '../components/BallotStepper';
 
 const Vote: React.FC = () => {
   const { id } = useParams();
@@ -28,6 +28,7 @@ const Vote: React.FC = () => {
   const { data: election } = useElection(electionId);
   const { data: allBallots } = useBallots(electionId);
   const [ballots, setBallots] = useState<Ballot[]>([]);
+  const [syncing, setSyncing] = useState(false);
   const { data: shareholders } = useShareholders(
     electionId,
     '',
@@ -48,18 +49,27 @@ const Vote: React.FC = () => {
   const currentIdRef = useRef<number | null>(null);
 
   useEffect(() => {
-    currentIdRef.current = ballots[currentStep]?.id ?? null;
-  }, [ballots, currentStep]);
-
-  useEffect(() => {
     if (!allBallots) return;
-    setBallots(allBallots);
+    setBallots((prev) => {
+      if (prev.length === 0) return allBallots;
+      let mismatch = false;
+      const merged = allBallots.map((b) => {
+        const local = prev.find((p) => p.id === b.id);
+        if (local && local.status === 'CLOSED' && b.status !== 'CLOSED') {
+          mismatch = true;
+          return { ...b, status: 'CLOSED' };
+        }
+        return b;
+      });
+      setSyncing(mismatch);
+      return merged;
+    });
     const currentId = currentIdRef.current;
     if (currentId != null) {
       const index = allBallots.findIndex((b) => b.id === currentId);
       if (index >= 0) {
         if (allBallots[index].status === 'OPEN') {
-          setCurrentStep(index);
+          advance(index, allBallots);
           return;
         }
         advance(index + 1, allBallots);
@@ -74,6 +84,8 @@ const Vote: React.FC = () => {
     while (next < list.length && list[next].status !== 'OPEN') {
       next++;
     }
+    const id = list[next]?.id ?? null;
+    currentIdRef.current = id;
     setCurrentStep(next);
   };
 
@@ -166,7 +178,9 @@ const Vote: React.FC = () => {
     while (prev >= 0 && ballots[prev].status !== 'OPEN') {
       prev--;
     }
-    if (prev >= 0) setCurrentStep(prev);
+    if (prev >= 0) {
+      advance(prev);
+    }
   };
 
   const total = ballots.length;
@@ -207,14 +221,15 @@ const Vote: React.FC = () => {
           </Button>
         </div>
       )}
+      {syncing && <Alert message="Sincronizando..." />}
       {election?.voting_open && current && (
         loadingOptions || fetchingOptions ? (
           <p>Cargando opciones...</p>
         ) : options && options.length > 0 ? (
-          <QuestionWizard
+          <BallotStepper
             key={current.id}
             ballots={ballots}
-            currentStep={currentStep}
+            currentBallotId={current.id}
             onNext={nextQuestion}
             onPrev={prevQuestion}
             nextDisabled={!allVoted}
@@ -260,7 +275,7 @@ const Vote: React.FC = () => {
                 </TableBody>
               </Table>
             )}
-          </QuestionWizard>
+          </BallotStepper>
         ) : (
           <div className="space-y-4">
             <h2 className="text-lg font-medium">{current.title}</h2>


### PR DESCRIPTION
## Summary
- ensure `advance` stores next ballot id immediately
- remove redundant effect that reset current ballot id

## Testing
- `npm test -- --run`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af15c9c2448322ac707329a630a94c